### PR TITLE
[codex] Fix Markdown repository links

### DIFF
--- a/.changeset/clean-paths-link.md
+++ b/.changeset/clean-paths-link.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix repository Markdown links to use relative paths instead of machine-local absolute paths.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Check changesets on pull requests
         if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changeset-release/')
-        run: corepack yarn changeset status
+        run: corepack yarn changeset status --since=origin/${{ github.base_ref }}
 
       - name: Build workspace for pull requests
         if: github.event_name == 'pull_request'

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ CI sets `NO_UPDATE_NOTIFIER=1` so AVA's update-check does not emit sandbox or pe
 
 The benchmark tooling lives in the private workspace `@mandel59/mojidata-api-bench`, not in the published `@mandel59/mojidata-api` compatibility facade.
 The native Node.js backends are now published as explicit packages instead of being part of the default portable runtime/facade install path.
-See [docs/mojidata-api-benchmarks.md](/Users/mandel59/ws/mojidata/docs/mojidata-api-benchmarks.md) for the baseline, branch comparison, and remote target workflows.
-See [docs/idsfind-fts-comparison.md](/Users/mandel59/ws/mojidata/docs/idsfind-fts-comparison.md) for the current FTS4/FTS5 decision on `idsfind.db`.
-See [docs/mojidata-api-d1-deployment.md](/Users/mandel59/ws/mojidata/docs/mojidata-api-d1-deployment.md) for the current D1 Worker deployment path and the Cloudflare integration options for `mojidata-web-app`.
+See [docs/mojidata-api-benchmarks.md](docs/mojidata-api-benchmarks.md) for the baseline, branch comparison, and remote target workflows.
+See [docs/idsfind-fts-comparison.md](docs/idsfind-fts-comparison.md) for the current FTS4/FTS5 decision on `idsfind.db`.
+See [docs/mojidata-api-d1-deployment.md](docs/mojidata-api-d1-deployment.md) for the current D1 Worker deployment path and the Cloudflare integration options for `mojidata-web-app`.
 
 ## Release
 
@@ -74,4 +74,4 @@ On pull requests, CI also runs `yarn changeset status`, so changes to publishabl
 4. Merge the release PR after CI passes.
 5. Confirm npm publish succeeded from the Actions run.
 
-See [docs/releasing.md](/Users/mandel59/ws/mojidata/docs/releasing.md) for GitHub secret requirements and the manual retry flow.
+See [docs/releasing.md](docs/releasing.md) for GitHub secret requirements and the manual retry flow.

--- a/docs/mojidata-api-benchmarks.md
+++ b/docs/mojidata-api-benchmarks.md
@@ -2,7 +2,7 @@
 
 `mojidata-api` backend benchmarks live in the private workspace `@mandel59/mojidata-api-bench`.
 
-The benchmark scenario set is defined and versioned in [packages/mojidata-api-bench/benchmarks/scenarios.json](/Users/mandel59/ws/mojidata/packages/mojidata-api-bench/benchmarks/scenarios.json). Keep that version stable when comparing historical results. If the scenario set changes, bump `scenarioSetVersion` in the manifest so older result files can be identified correctly.
+The benchmark scenario set is defined and versioned in [packages/mojidata-api-bench/benchmarks/scenarios.json](../packages/mojidata-api-bench/benchmarks/scenarios.json). Keep that version stable when comparing historical results. If the scenario set changes, bump `scenarioSetVersion` in the manifest so older result files can be identified correctly.
 
 ## Prepare
 
@@ -31,7 +31,7 @@ node ./packages/mojidata-api-bench/benchmarks/compare-idsfind-fts.mjs \
   --output artifacts/bench/idsfind-fts.json
 ```
 
-See [docs/idsfind-fts-comparison.md](/Users/mandel59/ws/mojidata/docs/idsfind-fts-comparison.md)
+See [docs/idsfind-fts-comparison.md](idsfind-fts-comparison.md)
 for the current decision and the latest recorded findings.
 
 ## Compare local backends

--- a/docs/mojidata-api-d1-deployment.md
+++ b/docs/mojidata-api-d1-deployment.md
@@ -85,7 +85,7 @@ It is not the right target for:
 
 The repository includes a private deployment workspace for this purpose:
 
-- [packages/mojidata-api-d1-worker](/Users/mandel59/ws/mojidata/packages/mojidata-api-d1-worker)
+- [packages/mojidata-api-d1-worker](../packages/mojidata-api-d1-worker)
 
 It wraps `createD1FetchHandler()` from `@mandel59/mojidata-api-d1` and exposes a
 minimal Worker entrypoint plus a `wrangler.jsonc` template. The same helper is
@@ -109,7 +109,7 @@ may therefore download the CLI.
 
 The `provision` helper reuses an existing database if `wrangler d1 info` can
 find it; otherwise it creates the database and rewrites
-[packages/mojidata-api-d1-worker/wrangler.jsonc](/Users/mandel59/ws/mojidata/packages/mojidata-api-d1-worker/wrangler.jsonc)
+[packages/mojidata-api-d1-worker/wrangler.jsonc](../packages/mojidata-api-d1-worker/wrangler.jsonc)
 with the resolved IDs.
 
 ## Standalone Worker setup

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "scripts": {
         "changeset": "changeset",
-        "build:idsdb-stack": "(cd packages/mojidata && yarn prepare) && (cd packages/idsdb && yarn prepare)",
+        "build:idsdb-stack": "(cd packages/mojidata && yarn prepare) && (cd packages/idsdb-utils && yarn prepare) && (cd packages/idsdb && yarn prepare)",
         "build:mojidata-api-split": "(cd packages/mojidata-api-core && yarn prepare) && (cd packages/mojidata-api-hono && yarn prepare) && (cd packages/mojidata-api-runtime && yarn prepare) && (cd packages/mojidata-api-sqljs && yarn prepare) && (cd packages/mojidata-api-better-sqlite3 && yarn prepare) && (cd packages/mojidata-api-node-sqlite && yarn prepare) && (cd packages/mojidata-api-d1 && yarn prepare)",
         "ci:build:affected": "node ./scripts/run-affected-workspaces.mjs build",
         "ci:build": "yarn build",

--- a/packages/idsdb-fts5/README.md
+++ b/packages/idsdb-fts5/README.md
@@ -19,7 +19,7 @@ corepack yarn workspace @mandel59/idsdb-fts5 prepare
 ```
 
 For the current compatibility report and the reason this remains a separate
-package, see [docs/idsfind-fts-comparison.md](/Users/mandel59/ws/mojidata/docs/idsfind-fts-comparison.md).
+package, see [docs/idsfind-fts-comparison.md](../../docs/idsfind-fts-comparison.md).
 
 ## License
 

--- a/packages/idsdb/README.md
+++ b/packages/idsdb/README.md
@@ -9,7 +9,7 @@ For backends that support SQLite FTS5, use the separate
 `@mandel59/idsdb-fts5` package, which publishes an FTS5-flavored `idsfind.db`.
 
 For the current compatibility decision and the recorded FTS4/FTS5 comparison,
-see [docs/idsfind-fts-comparison.md](/Users/mandel59/ws/mojidata/docs/idsfind-fts-comparison.md).
+see [docs/idsfind-fts-comparison.md](../../docs/idsfind-fts-comparison.md).
 
 ## License
 

--- a/packages/mojidata-api-bench/README.md
+++ b/packages/mojidata-api-bench/README.md
@@ -4,7 +4,7 @@ Internal benchmark tooling for comparing `mojidata-api` backends and deployments
 
 This workspace is private and is not published to npm.
 
-The benchmark scenario set is versioned in [benchmarks/scenarios.json](/Users/mandel59/ws/mojidata/packages/mojidata-api-bench/benchmarks/scenarios.json).
+The benchmark scenario set is versioned in [benchmarks/scenarios.json](benchmarks/scenarios.json).
 
 Common commands from the repository root:
 

--- a/packages/mojidata-api-d1-worker/README.md
+++ b/packages/mojidata-api-d1-worker/README.md
@@ -11,8 +11,8 @@ It is not a published package. Its purpose is to provide:
 
 ## Files
 
-- [src/index.ts](/Users/mandel59/ws/mojidata/packages/mojidata-api-d1-worker/src/index.ts)
-- [wrangler.jsonc](/Users/mandel59/ws/mojidata/packages/mojidata-api-d1-worker/wrangler.jsonc)
+- [src/index.ts](src/index.ts)
+- [wrangler.jsonc](wrangler.jsonc)
 
 ## Usage
 
@@ -46,4 +46,4 @@ has production-like smoke and benchmark results.
 
 For the full setup flow and the Cloudflare integration notes for
 `mojidata-web-app`, see
-[docs/mojidata-api-d1-deployment.md](/Users/mandel59/ws/mojidata/docs/mojidata-api-d1-deployment.md).
+[docs/mojidata-api-d1-deployment.md](../../docs/mojidata-api-d1-deployment.md).

--- a/packages/mojidata-api-d1/README.md
+++ b/packages/mojidata-api-d1/README.md
@@ -46,9 +46,9 @@ compatibility, and D1 data import flow.
 
 For a deployable Cloudflare Worker target in this repository, see the private
 workspace
-[packages/mojidata-api-d1-worker](/Users/mandel59/ws/mojidata/packages/mojidata-api-d1-worker)
+[packages/mojidata-api-d1-worker](../mojidata-api-d1-worker)
 and
-[docs/mojidata-api-d1-deployment.md](/Users/mandel59/ws/mojidata/docs/mojidata-api-d1-deployment.md).
+[docs/mojidata-api-d1-deployment.md](../../docs/mojidata-api-d1-deployment.md).
 
 For local D1-oriented `idsfind` assets, use the separate `@mandel59/idsdb-fts5`
 package:
@@ -107,4 +107,4 @@ directory, along with comparison files for:
 - `node:sqlite` vs D1
 
 For more detail, see
-[docs/mojidata-api-benchmarks.md](/Users/mandel59/ws/mojidata/docs/mojidata-api-benchmarks.md).
+[docs/mojidata-api-benchmarks.md](../../docs/mojidata-api-benchmarks.md).


### PR DESCRIPTION
## Summary

- Replace machine-local `/Users/mandel59/ws/mojidata/...` Markdown link targets with repository-relative paths.
- Update README links in root docs, package docs, and D1/benchmark docs so they work outside this checkout.
- Add an empty changeset for the documentation-only package README updates.
- Fix PR validation by running `changeset status` against the fetched base ref.
- Build `idsdb-utils` before `idsdb` in the root idsdb stack build so clean CI checkouts have the generated utility files needed by `idsdb` input hashing.

## Validation

- `rg -n --glob '*.md' '(/Users/mandel59/ws/mojidata|file:///Users/mandel59/ws/mojidata|/private/tmp|/home/runner/work|/workspace/)'` returned no matches.
- Custom Node link resolver validated the 8 changed Markdown files.
- `python3 packages/idsdb/scripts/input-hash.py` completed successfully locally.
- GitHub Actions `validate` passed on run `25258070256`.