### PR TITLE
[codex] Cache idsdb artifacts in CI

### DIFF
--- a/.changeset/quiet-idsdb-cache.md
+++ b/.changeset/quiet-idsdb-cache.md
@@ -1,0 +1,5 @@
+---
+---
+
+Cache generated `idsdb` and `idsdb-fts5` database artifacts in CI so unchanged
+database inputs do not rebuild from scratch on every fresh runner.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,20 @@ jobs:
           restore-keys: |
             mojidata-${{ runner.os }}-
 
+      - name: Restore idsdb build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/idsdb/idsfind.db
+            packages/idsdb/idsdecompose.db
+            packages/idsdb/.idsdb.input.sha256
+            packages/idsdb-fts5/idsfind.db
+            packages/idsdb-fts5/idsdecompose.db
+            packages/idsdb-fts5/.idsdb-fts5.input.sha256
+          key: idsdb-${{ runner.os }}-${{ hashFiles('packages/mojidata/download.txt', 'packages/mojidata/package.json', 'packages/mojidata/scripts/**', 'packages/mojidata/build-data/unihan-tr38-properties.json', 'packages/idsdb/package.json', 'packages/idsdb/tsconfig.json', 'packages/idsdb/prepare.ts', 'packages/idsdb/scripts/**', 'packages/idsdb-fts5/package.json', 'packages/idsdb-fts5/scripts/**', 'packages/idsdb-utils/package.json', 'packages/idsdb-utils/tsconfig.json', 'packages/idsdb-utils/index.ts', 'packages/idsdb-utils/node.ts', 'packages/idsdb-utils/lib/**') }}
+          restore-keys: |
+            idsdb-${{ runner.os }}-
+
       - name: Install dependencies
         run: corepack yarn install --immutable
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,6 +41,20 @@ jobs:
           restore-keys: |
             mojidata-${{ runner.os }}-
 
+      - name: Restore idsdb build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/idsdb/idsfind.db
+            packages/idsdb/idsdecompose.db
+            packages/idsdb/.idsdb.input.sha256
+            packages/idsdb-fts5/idsfind.db
+            packages/idsdb-fts5/idsdecompose.db
+            packages/idsdb-fts5/.idsdb-fts5.input.sha256
+          key: idsdb-${{ runner.os }}-${{ hashFiles('packages/mojidata/download.txt', 'packages/mojidata/package.json', 'packages/mojidata/scripts/**', 'packages/mojidata/build-data/unihan-tr38-properties.json', 'packages/idsdb/package.json', 'packages/idsdb/tsconfig.json', 'packages/idsdb/prepare.ts', 'packages/idsdb/scripts/**', 'packages/idsdb-fts5/package.json', 'packages/idsdb-fts5/scripts/**', 'packages/idsdb-utils/package.json', 'packages/idsdb-utils/tsconfig.json', 'packages/idsdb-utils/index.ts', 'packages/idsdb-utils/node.ts', 'packages/idsdb-utils/lib/**') }}
+          restore-keys: |
+            idsdb-${{ runner.os }}-
+
       - name: Install dependencies
         run: corepack yarn install --immutable
 


### PR DESCRIPTION
## Summary

- Add an Actions cache step for generated `idsdb` and `idsdb-fts5` SQLite artifacts plus their input-hash stamp files.
- Use mojidata, idsdb, idsdb-fts5, and idsdb-utils input files in the cache key so unchanged DB inputs can restore artifacts instead of rebuilding on fresh runners.
- Add an empty changeset for the CI-only workflow change.

## Why

Full CI runs currently rebuild `idsdb` when a fresh runner has no `idsfind.db` or `.idsdb.input.sha256`, even if the PR did not touch DB inputs. Restoring those artifacts lets the existing `prepare` hash checks print `inputs unchanged, skipping rebuild` when the cache is valid.

## Validation

- Parsed `.github/workflows/validate.yml` and `.github/workflows/release.yml` with Ruby YAML.
- Confirmed local diff is limited to the workflow cache steps and empty changeset.

Related: #23