### PR TITLE
[codex] Add mojidata-api bundler-safe entrypoints

### DIFF
--- a/.changeset/silver-entrypoints-bundle.md
+++ b/.changeset/silver-entrypoints-bundle.md
@@ -1,0 +1,9 @@
+---
+"@mandel59/mojidata-api": minor
+"@mandel59/mojidata-api-runtime": minor
+"@mandel59/mojidata-api-sqlite-wasm": minor
+---
+
+Add documented bundler-safe mojidata-api entrypoints, public runtime/sqlite-wasm
+subpath exports, static entrypoint smoke tests, and sqlite-wasm idsfind FTS5
+schema validation.

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -98,7 +98,7 @@ const RAW_RUNTIME_STATE =
     ["@mandel59/mojidata", ["workspace:packages/mojidata"]],\
     ["@mandel59/mojidata-api", ["workspace:packages/mojidata-api"]],\
     ["@mandel59/mojidata-api-bench", ["workspace:packages/mojidata-api-bench"]],\
-    ["@mandel59/mojidata-api-better-sqlite3", ["virtual:786ff3bbd6eef7688a833439a338e46d6a1c41d5fd70226af8748ed2e6ea5e91db2c741160011bc5d1947617ca1a1682e3ff4cb4aa28f74212bb5b59b725f144#workspace:packages/mojidata-api-better-sqlite3", "workspace:packages/mojidata-api-better-sqlite3"]],\
+    ["@mandel59/mojidata-api-better-sqlite3", ["virtual:ca6edadad433d65c39ebb39027a1d28c743bddfc96e82cefc8a9f411e468c283944545c6edc1e7c5f95e4ea41c705612099495a04e85cc8ea62528e6165b6c5a#workspace:packages/mojidata-api-better-sqlite3", "workspace:packages/mojidata-api-better-sqlite3"]],\
     ["@mandel59/mojidata-api-core", ["workspace:packages/mojidata-api-core"]],\
     ["@mandel59/mojidata-api-d1", ["workspace:packages/mojidata-api-d1"]],\
     ["@mandel59/mojidata-api-d1-worker", ["workspace:packages/mojidata-api-d1-worker"]],\
@@ -1167,8 +1167,10 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@hono/node-server", "virtual:ca6edadad433d65c39ebb39027a1d28c743bddfc96e82cefc8a9f411e468c283944545c6edc1e7c5f95e4ea41c705612099495a04e85cc8ea62528e6165b6c5a#npm:1.19.7"],\
           ["@mandel59/mojidata-api", "workspace:packages/mojidata-api"],\
+          ["@mandel59/mojidata-api-better-sqlite3", "virtual:ca6edadad433d65c39ebb39027a1d28c743bddfc96e82cefc8a9f411e468c283944545c6edc1e7c5f95e4ea41c705612099495a04e85cc8ea62528e6165b6c5a#workspace:packages/mojidata-api-better-sqlite3"],\
           ["@mandel59/mojidata-api-core", "workspace:packages/mojidata-api-core"],\
           ["@mandel59/mojidata-api-hono", "workspace:packages/mojidata-api-hono"],\
+          ["@mandel59/mojidata-api-node-sqlite", "workspace:packages/mojidata-api-node-sqlite"],\
           ["@mandel59/mojidata-api-runtime", "workspace:packages/mojidata-api-runtime"],\
           ["@mandel59/mojidata-api-sqljs", "workspace:packages/mojidata-api-sqljs"],\
           ["@types/node", "npm:24.10.4"],\
@@ -1185,7 +1187,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/mojidata-api-bench/",\
         "packageDependencies": [\
           ["@mandel59/mojidata-api-bench", "workspace:packages/mojidata-api-bench"],\
-          ["@mandel59/mojidata-api-better-sqlite3", "virtual:786ff3bbd6eef7688a833439a338e46d6a1c41d5fd70226af8748ed2e6ea5e91db2c741160011bc5d1947617ca1a1682e3ff4cb4aa28f74212bb5b59b725f144#workspace:packages/mojidata-api-better-sqlite3"],\
+          ["@mandel59/mojidata-api-better-sqlite3", "virtual:ca6edadad433d65c39ebb39027a1d28c743bddfc96e82cefc8a9f411e468c283944545c6edc1e7c5f95e4ea41c705612099495a04e85cc8ea62528e6165b6c5a#workspace:packages/mojidata-api-better-sqlite3"],\
           ["@mandel59/mojidata-api-node-sqlite", "workspace:packages/mojidata-api-node-sqlite"],\
           ["@mandel59/mojidata-api-sqljs", "workspace:packages/mojidata-api-sqljs"],\
           ["@types/node", "npm:24.10.4"],\
@@ -1197,12 +1199,12 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@mandel59/mojidata-api-better-sqlite3", [\
-      ["virtual:786ff3bbd6eef7688a833439a338e46d6a1c41d5fd70226af8748ed2e6ea5e91db2c741160011bc5d1947617ca1a1682e3ff4cb4aa28f74212bb5b59b725f144#workspace:packages/mojidata-api-better-sqlite3", {\
-        "packageLocation": "./.yarn/__virtual__/@mandel59-mojidata-api-better-sqlite3-virtual-9374ea863f/1/packages/mojidata-api-better-sqlite3/",\
+      ["virtual:ca6edadad433d65c39ebb39027a1d28c743bddfc96e82cefc8a9f411e468c283944545c6edc1e7c5f95e4ea41c705612099495a04e85cc8ea62528e6165b6c5a#workspace:packages/mojidata-api-better-sqlite3", {\
+        "packageLocation": "./.yarn/__virtual__/@mandel59-mojidata-api-better-sqlite3-virtual-2b63c2bef4/1/packages/mojidata-api-better-sqlite3/",\
         "packageDependencies": [\
           ["@mandel59/idsdb-fts5", "workspace:packages/idsdb-fts5"],\
           ["@mandel59/mojidata", "workspace:packages/mojidata"],\
-          ["@mandel59/mojidata-api-better-sqlite3", "virtual:786ff3bbd6eef7688a833439a338e46d6a1c41d5fd70226af8748ed2e6ea5e91db2c741160011bc5d1947617ca1a1682e3ff4cb4aa28f74212bb5b59b725f144#workspace:packages/mojidata-api-better-sqlite3"],\
+          ["@mandel59/mojidata-api-better-sqlite3", "virtual:ca6edadad433d65c39ebb39027a1d28c743bddfc96e82cefc8a9f411e468c283944545c6edc1e7c5f95e4ea41c705612099495a04e85cc8ea62528e6165b6c5a#workspace:packages/mojidata-api-better-sqlite3"],\
           ["@mandel59/mojidata-api-core", "workspace:packages/mojidata-api-core"],\
           ["@mandel59/mojidata-api-hono", "workspace:packages/mojidata-api-hono"],\
           ["@types/better-sqlite3", "npm:5.4.2"],\
@@ -1210,9 +1212,6 @@ const RAW_RUNTIME_STATE =
           ["better-sqlite3", "npm:12.5.0"],\
           ["tsx", "npm:4.21.0"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"]\
-        ],\
-        "packagePeers": [\
-          "better-sqlite3"\
         ],\
         "linkType": "SOFT"\
       }],\

--- a/packages/mojidata-api-runtime/package.json
+++ b/packages/mojidata-api-runtime/package.json
@@ -15,6 +15,16 @@
       "require": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./browser-client": {
+      "types": "./dist/lib/browser-client.d.ts",
+      "require": "./dist/lib/browser-client.js",
+      "default": "./dist/lib/browser-client.js"
+    },
+    "./worker-protocol": {
+      "types": "./dist/lib/worker-protocol.d.ts",
+      "require": "./dist/lib/worker-protocol.js",
+      "default": "./dist/lib/worker-protocol.js"
+    },
     "./lib/*": {
       "types": "./dist/lib/*.d.ts",
       "require": "./dist/lib/*.js",

--- a/packages/mojidata-api-sqlite-wasm/README.md
+++ b/packages/mojidata-api-sqlite-wasm/README.md
@@ -18,6 +18,14 @@ It includes:
 - `createSqliteWasmDbFromOpfsSAHPool()`: wires OPFS DB handles to `createSqlApiDb()`
 - `@mandel59/mojidata-api-sqlite-wasm/browser-worker`: worker entrypoint using the shared mojidata-api worker protocol
 
+Public subpaths:
+
+- `@mandel59/mojidata-api-sqlite-wasm/browser-worker`
+- `@mandel59/mojidata-api-sqlite-wasm/opfs-sahpool`
+- `@mandel59/mojidata-api-sqlite-wasm/sqlite-wasm-executor`
+
+Use these public subpaths instead of private `lib/*` paths.
+
 Example worker client:
 
 ```ts
@@ -52,6 +60,27 @@ directly when they need lower-level control.
 The browser worker initializes SQLite and the OPFS pool during `ready`, but DB
 assets are imported lazily. `moji.db` is downloaded/imported on the first
 mojidata query, and `idsfind.db` is downloaded/imported on the first IDS query.
+
+## idsfind DB requirement
+
+SQLite wasm supports FTS5 but not the legacy FTS4 module used by
+`@mandel59/idsdb`. For sqlite-wasm backends, `idsfindDbUrl` must point at the
+FTS5 database from `@mandel59/idsdb-fts5`.
+
+The OPFS runtime validates the `idsfind_fts` virtual table before creating the
+idsfind executor. If an FTS4 database is supplied, initialization fails with
+`SqliteWasmIdsfindSchemaError` and a message that points to
+`@mandel59/idsdb-fts5`.
+
+Typical browser asset wiring:
+
+```ts
+const db = createMojidataApiWorkerClient(worker, {
+  sqlWasmUrl: "/assets/sqlite3.wasm",
+  mojidataDbUrl: "/assets/moji.db",
+  idsfindDbUrl: "/assets/idsfind-fts5.db",
+})
+```
 
 `opfs-sahpool` is only available from Worker contexts with OPFS APIs. In
 unsupported contexts, use `tryEnsureOpfsSAHPoolDatabase()` or catch

--- a/packages/mojidata-api-sqlite-wasm/index.ts
+++ b/packages/mojidata-api-sqlite-wasm/index.ts
@@ -2,10 +2,14 @@ export {
   createSqliteWasmDb,
   createSqliteWasmDbFromOpfsSAHPool,
   createSqliteWasmExecutorProvider,
+  createSqliteWasmIdsfindDbProvider,
   createSqliteWasmMojidataDbProvider,
   openOpfsSAHPoolDatabase,
+  assertSqliteWasmIdsfindFts5Schema,
   type CreateSqliteWasmDbFromOpfsSAHPoolOptions,
+  type SqliteWasmIdsfindSchemaDatabase,
 } from "./lib/sqlite-wasm-runtime.js"
+export { SqliteWasmIdsfindSchemaError } from "./lib/sqlite-wasm-runtime.js"
 export {
   createSqliteWasmExecutor,
   type SqliteWasmDatabaseLike,

--- a/packages/mojidata-api-sqlite-wasm/lib/sqlite-wasm-runtime.ts
+++ b/packages/mojidata-api-sqlite-wasm/lib/sqlite-wasm-runtime.ts
@@ -56,6 +56,41 @@ export type CreateSqliteWasmDbFromOpfsSAHPoolOptions = {
   idsfind: OpfsSAHPoolMaterializeOptions
 }
 
+export class SqliteWasmIdsfindSchemaError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "SqliteWasmIdsfindSchemaError"
+  }
+}
+
+export type SqliteWasmIdsfindSchemaDatabase = Pick<Database, "selectObject">
+
+export function assertSqliteWasmIdsfindFts5Schema(
+  db: SqliteWasmIdsfindSchemaDatabase,
+) {
+  const row = db.selectObject(
+    "SELECT sql FROM sqlite_master WHERE name = 'idsfind_fts'",
+  ) as { sql?: string } | undefined
+  const sql = row?.sql ?? ""
+  if (/\bUSING\s+fts5\b/iu.test(sql)) return
+
+  const detected = /\bUSING\s+fts4\b/iu.test(sql) ? "FTS4" : "a non-FTS5"
+  throw new SqliteWasmIdsfindSchemaError(
+    `sqlite-wasm idsfind requires an FTS5 idsfind.db from @mandel59/idsdb-fts5; supplied database appears to use ${detected} schema.`,
+  )
+}
+
+export function createSqliteWasmIdsfindDbProvider(openDatabase: DatabaseOpener) {
+  let dbPromise: Promise<SqlExecutor> | undefined
+  return function getDb(): Promise<SqlExecutor> {
+    dbPromise ??= Promise.resolve(openDatabase()).then((db) => {
+      assertSqliteWasmIdsfindFts5Schema(db)
+      return createSqliteWasmExecutor(db)
+    })
+    return dbPromise
+  }
+}
+
 export async function createSqliteWasmDbFromOpfsSAHPool({
   poolUtil,
   mojidata,
@@ -66,7 +101,7 @@ export async function createSqliteWasmDbFromOpfsSAHPool({
       await ensureOpfsSAHPoolDatabase(poolUtil, mojidata)
       return openOpfsSAHPoolDatabase(poolUtil, mojidata.name)
     }),
-    getIdsfindDb: createSqliteWasmExecutorProvider(async () => {
+    getIdsfindDb: createSqliteWasmIdsfindDbProvider(async () => {
       await ensureOpfsSAHPoolDatabase(poolUtil, idsfind)
       return openOpfsSAHPoolDatabase(poolUtil, idsfind.name)
     }),

--- a/packages/mojidata-api-sqlite-wasm/package.json
+++ b/packages/mojidata-api-sqlite-wasm/package.json
@@ -21,6 +21,16 @@
       "import": "./dist/browser-worker.js",
       "default": "./dist/browser-worker.js"
     },
+    "./opfs-sahpool": {
+      "types": "./dist/lib/opfs-sahpool.d.ts",
+      "import": "./dist/lib/opfs-sahpool.js",
+      "default": "./dist/lib/opfs-sahpool.js"
+    },
+    "./sqlite-wasm-executor": {
+      "types": "./dist/lib/sqlite-wasm-executor.d.ts",
+      "import": "./dist/lib/sqlite-wasm-executor.js",
+      "default": "./dist/lib/sqlite-wasm-executor.js"
+    },
     "./lib/*": {
       "types": "./dist/lib/*.d.ts",
       "import": "./dist/lib/*.js",

--- a/packages/mojidata-api-sqlite-wasm/tests/sqlite-wasm-executor.test.ts
+++ b/packages/mojidata-api-sqlite-wasm/tests/sqlite-wasm-executor.test.ts
@@ -9,8 +9,11 @@ import {
   installMojidataSqliteWasmFunctions,
   isOpfsSAHPoolSupported,
   openOpfsSAHPoolDatabase,
+  assertSqliteWasmIdsfindFts5Schema,
+  SqliteWasmIdsfindSchemaError,
   tryEnsureOpfsSAHPoolDatabase,
   tryInstallOpfsSAHPool,
+  type SqliteWasmIdsfindSchemaDatabase,
   type SqliteWasmSAHPoolUtil,
 } from "../index.js"
 
@@ -142,5 +145,41 @@ describe("OPFS fallback helpers", () => {
     if (!result.ok) {
       assert.equal(result.reason, "unsupported")
     }
+  })
+})
+
+describe("sqlite-wasm idsfind schema validation", () => {
+  function schemaDb(sql: string | undefined): SqliteWasmIdsfindSchemaDatabase {
+    return {
+      selectObject() {
+        return sql === undefined ? undefined : { sql }
+      },
+    } as SqliteWasmIdsfindSchemaDatabase
+  }
+
+  test("accepts an FTS5 idsfind virtual table", () => {
+    assert.doesNotThrow(() =>
+      assertSqliteWasmIdsfindFts5Schema(
+        schemaDb('CREATE VIRTUAL TABLE "idsfind_fts" USING fts5 ("IDS_tokens")'),
+      ),
+    )
+  })
+
+  test("rejects an FTS4 idsfind virtual table with package guidance", () => {
+    assert.throws(
+      () =>
+        assertSqliteWasmIdsfindFts5Schema(
+          schemaDb('CREATE VIRTUAL TABLE "idsfind_fts" USING fts4 ("IDS_tokens")'),
+        ),
+      (error) =>
+        error instanceof SqliteWasmIdsfindSchemaError &&
+        error.message.includes("@mandel59/idsdb-fts5") &&
+        error.message.includes("FTS4"),
+    )
+  })
+
+  test("public OPFS subpath is importable", async () => {
+    const opfs = await import("@mandel59/mojidata-api-sqlite-wasm/opfs-sahpool")
+    assert.equal(typeof opfs.ensureOpfsSAHPoolDatabase, "function")
   })
 })

--- a/packages/mojidata-api/README.md
+++ b/packages/mojidata-api/README.md
@@ -17,6 +17,30 @@ It also has split packages for composing the API yourself:
 
 The original `@mandel59/mojidata-api/*` subpath entrypoints remain available as compatibility facades and forward to the split packages.
 
+## Bundler-safe entrypoints
+
+For bundled applications, choose the narrowest entrypoint for the runtime you
+are targeting. The root compatibility facade is convenient for Node scripts, but
+apps such as Cloudflare Workers, OpenNext, browser SPAs, and Web Workers should
+avoid importing backend packages they do not use.
+
+| Target | Import | Notes |
+| --- | --- | --- |
+| Hono app wiring | `@mandel59/mojidata-api/app` | Edge-safe app factory. Does not select a database backend. |
+| Browser worker client | `@mandel59/mojidata-api/browser-client` | Re-exports the shared worker client. |
+| Worker protocol types | `@mandel59/mojidata-api/worker-protocol` | Type-only protocol surface for custom workers. |
+| Browser SQL.js worker | `@mandel59/mojidata-api/browser-worker` | Compatibility SQL.js worker entrypoint. |
+| Node SQL.js backend | `@mandel59/mojidata-api/node-sqljs` | Portable Node backend without native SQLite packages. |
+| Node `better-sqlite3` backend | `@mandel59/mojidata-api/node-better-sqlite3` | Requires installing `@mandel59/mojidata-api-better-sqlite3` and its `better-sqlite3` peer. |
+| Node `node:sqlite` backend | `@mandel59/mojidata-api/node-sqlite` | Requires installing `@mandel59/mojidata-api-node-sqlite`. |
+| SQLite wasm OPFS backend | `@mandel59/mojidata-api-sqlite-wasm` | Use the split ESM package directly for browser OPFS. |
+| SQLite wasm OPFS helpers | `@mandel59/mojidata-api-sqlite-wasm/opfs-sahpool` | Stable public helper subpath; avoid private `lib/*` imports. |
+
+`@mandel59/mojidata-api/node-better-sqlite3` and
+`@mandel59/mojidata-api/node-sqlite` are optional facade subpaths. They do not
+make native backends part of the default dependency path; install the matching
+split backend package when you import those subpaths.
+
 For Node.js compatibility usage, `createNodeDb()` in this package uses the portable `sql.js` backend:
 
 ```ts
@@ -25,7 +49,9 @@ import { createNodeDb } from "@mandel59/mojidata-api"
 const db = createNodeDb()
 ```
 
-For new code that selects the backend explicitly, prefer `@mandel59/mojidata-api-sqljs`.
+For new code that selects the backend explicitly, prefer
+`@mandel59/mojidata-api/node-sqljs` or the split
+`@mandel59/mojidata-api-sqljs` package.
 For browser SPAs that need persistent OPFS storage, use
 `@mandel59/mojidata-api-sqlite-wasm` explicitly.
 
@@ -134,6 +160,10 @@ const body = await res.json()
 // Cleanup when you're done:
 db.terminate()
 ```
+
+Custom browser workers can import protocol types from
+`@mandel59/mojidata-api/worker-protocol` instead of reaching into
+`@mandel59/mojidata-api-runtime/lib/*`.
 
 ## Advanced composition
 

--- a/packages/mojidata-api/node-better-sqlite3.ts
+++ b/packages/mojidata-api/node-better-sqlite3.ts
@@ -1,0 +1,7 @@
+export {
+  createBetterSqlite3App,
+  createBetterSqlite3Db,
+  createBetterSqlite3Executor,
+  createBetterSqlite3ExecutorProvider,
+  createBetterSqlite3MojidataDbProvider,
+} from "@mandel59/mojidata-api-better-sqlite3"

--- a/packages/mojidata-api/node-sqlite.ts
+++ b/packages/mojidata-api/node-sqlite.ts
@@ -1,0 +1,7 @@
+export {
+  createNodeSqliteApp,
+  createNodeSqliteDb,
+  createNodeSqliteExecutor,
+  createNodeSqliteExecutorProvider,
+  createNodeSqliteMojidataDbProvider,
+} from "@mandel59/mojidata-api-node-sqlite"

--- a/packages/mojidata-api/node-sqljs.ts
+++ b/packages/mojidata-api/node-sqljs.ts
@@ -1,0 +1,9 @@
+export {
+  createSqlJsApp,
+  createSqlJsDb,
+  createMojidataDbProvider,
+  installMojidataSqlFunctions,
+  createSqlJsExecutor,
+  getSqlJsNode,
+  openDatabaseFromFile,
+} from "@mandel59/mojidata-api-sqljs"

--- a/packages/mojidata-api/package.json
+++ b/packages/mojidata-api/package.json
@@ -45,6 +45,21 @@
       "require": "./dist/node.js",
       "default": "./dist/node.js"
     },
+    "./node-better-sqlite3": {
+      "types": "./dist/node-better-sqlite3.d.ts",
+      "require": "./dist/node-better-sqlite3.js",
+      "default": "./dist/node-better-sqlite3.js"
+    },
+    "./node-sqlite": {
+      "types": "./dist/node-sqlite.d.ts",
+      "require": "./dist/node-sqlite.js",
+      "default": "./dist/node-sqlite.js"
+    },
+    "./node-sqljs": {
+      "types": "./dist/node-sqljs.d.ts",
+      "require": "./dist/node-sqljs.js",
+      "default": "./dist/node-sqljs.js"
+    },
     "./runtime": {
       "types": "./dist/runtime.d.ts",
       "require": "./dist/runtime.js",
@@ -54,6 +69,11 @@
       "types": "./dist/sqljs.d.ts",
       "require": "./dist/sqljs.js",
       "default": "./dist/sqljs.js"
+    },
+    "./worker-protocol": {
+      "types": "./dist/worker-protocol.d.ts",
+      "require": "./dist/worker-protocol.js",
+      "default": "./dist/worker-protocol.js"
     },
     "./api/v1/_lib/*": {
       "types": "./dist/api/v1/_lib/*.d.ts",
@@ -72,7 +92,7 @@
     "start": "node --import tsx ./server.ts",
     "dev": "tsx watch ./server.ts",
     "prepare": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && tsc",
-    "prepare:test-deps": "yarn --cwd ../.. workspace @mandel59/mojidata run prepare && yarn --cwd ../.. workspace @mandel59/idsdb run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-core run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-hono run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-runtime run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-sqljs run prepare",
+    "prepare:test-deps": "yarn --cwd ../.. workspace @mandel59/mojidata run prepare && yarn --cwd ../.. workspace @mandel59/idsdb run prepare && yarn --cwd ../.. workspace @mandel59/idsdb-fts5 run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-core run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-hono run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-runtime run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-sqljs run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-better-sqlite3 run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-node-sqlite run prepare",
     "publish": "yarn prepare && yarn npm publish --access public",
     "test": "yarn run prepare:test-deps && yarn prepare && node --import tsx --test ./tests/*.test.ts",
     "test:ci": "yarn run prepare:test-deps && yarn prepare && node --import tsx --test ./tests/*.test.ts"
@@ -87,15 +107,25 @@
     "@mandel59/mojidata-api-sqljs": "^1.8.0"
   },
   "peerDependencies": {
-    "@hono/node-server": "^1.19.7"
+    "@hono/node-server": "^1.19.7",
+    "@mandel59/mojidata-api-better-sqlite3": "^1.8.0",
+    "@mandel59/mojidata-api-node-sqlite": "^1.8.0"
   },
   "peerDependenciesMeta": {
     "@hono/node-server": {
+      "optional": true
+    },
+    "@mandel59/mojidata-api-better-sqlite3": {
+      "optional": true
+    },
+    "@mandel59/mojidata-api-node-sqlite": {
       "optional": true
     }
   },
   "devDependencies": {
     "@hono/node-server": "^1.19.7",
+    "@mandel59/mojidata-api-better-sqlite3": "^1.8.0",
+    "@mandel59/mojidata-api-node-sqlite": "^1.8.0",
     "@types/node": "^24.10.4",
     "@types/sql.js": "^1.4.9",
     "prettier": "^2.8.8",

--- a/packages/mojidata-api/tests/bundler-entrypoints.test.ts
+++ b/packages/mojidata-api/tests/bundler-entrypoints.test.ts
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import { builtinModules } from "node:module"
+import path from "node:path"
+import { describe, test } from "node:test"
+
+type PackageJson = {
+  name: string
+  exports?: Record<string, string | Record<string, string>>
+}
+
+const workspaceRoot = path.resolve(__dirname, "..", "..", "..")
+const workspacePackages = new Map<string, string>()
+const builtinModuleSpecifiers = new Set([
+  ...builtinModules,
+  ...builtinModules.map((name) => `node:${name}`),
+])
+for (const entry of fs.readdirSync(path.join(workspaceRoot, "packages"))) {
+  const packageDir = path.join(workspaceRoot, "packages", entry)
+  const packageJsonPath = path.join(packageDir, "package.json")
+  if (!fs.existsSync(packageJsonPath)) continue
+  const packageJson = JSON.parse(
+    fs.readFileSync(packageJsonPath, "utf8"),
+  ) as PackageJson
+  workspacePackages.set(packageJson.name, packageDir)
+}
+
+function readPackageJson(packageDir: string) {
+  return JSON.parse(
+    fs.readFileSync(path.join(packageDir, "package.json"), "utf8"),
+  ) as PackageJson
+}
+
+function exportTarget(packageDir: string, subpath: string, condition: string) {
+  const packageJson = readPackageJson(packageDir)
+  const value = packageJson.exports?.[subpath]
+  if (typeof value === "string") return value
+  if (!value) throw new Error(`${packageJson.name} does not export ${subpath}`)
+  return value[condition] ?? value.default ?? value.require ?? value.import
+}
+
+function resolveFileWithoutExtension(base: string) {
+  for (const candidate of [base, `${base}.js`, `${base}.mjs`, `${base}.cjs`]) {
+    if (fs.existsSync(candidate)) return candidate
+  }
+  throw new Error(`Cannot resolve file: ${base}`)
+}
+
+function resolveRelativeImport(fromFile: string, specifier: string) {
+  return resolveFileWithoutExtension(path.resolve(path.dirname(fromFile), specifier))
+}
+
+function splitPackageSpecifier(specifier: string) {
+  const parts = specifier.split("/")
+  if (specifier.startsWith("@")) {
+    return {
+      packageName: `${parts[0]}/${parts[1]}`,
+      subpath: parts.length > 2 ? `./${parts.slice(2).join("/")}` : ".",
+    }
+  }
+  return {
+    packageName: parts[0],
+    subpath: parts.length > 1 ? `./${parts.slice(1).join("/")}` : ".",
+  }
+}
+
+function resolveWorkspaceImport(specifier: string, condition: string) {
+  const { packageName, subpath } = splitPackageSpecifier(specifier)
+  const packageDir = workspacePackages.get(packageName)
+  if (!packageDir) return undefined
+  return path.join(packageDir, exportTarget(packageDir, subpath, condition))
+}
+
+function staticImports(file: string) {
+  const source = fs.readFileSync(file, "utf8")
+  const imports = new Set<string>()
+  for (const pattern of [
+    /\brequire\(\s*["']([^"']+)["']\s*\)/gu,
+    /\bfrom\s+["']([^"']+)["']/gu,
+    /\bimport\s+["']([^"']+)["']/gu,
+  ]) {
+    for (const match of source.matchAll(pattern)) {
+      imports.add(match[1])
+    }
+  }
+  return [...imports]
+}
+
+function collectStaticGraph(entryFile: string, condition: string) {
+  const visited = new Set<string>()
+  const external = new Set<string>()
+  const files: string[] = []
+
+  function visit(file: string) {
+    const resolved = resolveFileWithoutExtension(file)
+    if (visited.has(resolved)) return
+    visited.add(resolved)
+    files.push(resolved)
+
+    for (const specifier of staticImports(resolved)) {
+      if (specifier.startsWith(".")) {
+        visit(resolveRelativeImport(resolved, specifier))
+        continue
+      }
+      const workspaceFile = resolveWorkspaceImport(specifier, condition)
+      if (workspaceFile) {
+        visit(workspaceFile)
+        continue
+      }
+      external.add(specifier)
+    }
+  }
+
+  visit(entryFile)
+  return { files, external: [...external].sort() }
+}
+
+function assertNoExternalImports(
+  entry: string,
+  external: string[],
+  banned: RegExp[],
+) {
+  const offenders = external.filter((specifier) =>
+    banned.some((pattern) => pattern.test(specifier)),
+  )
+  assert.deepEqual(
+    offenders,
+    [],
+    `${entry} statically imports banned modules: ${offenders.join(", ")}`,
+  )
+}
+
+function assertNoBuiltinImports(entry: string, external: string[]) {
+  const offenders = external.filter((specifier) =>
+    builtinModuleSpecifiers.has(specifier),
+  )
+  assert.deepEqual(
+    offenders,
+    [],
+    `${entry} statically imports Node builtins: ${offenders.join(", ")}`,
+  )
+}
+
+describe("bundler-safe entrypoint graph", () => {
+  const facadeDir = path.join(workspaceRoot, "packages", "mojidata-api")
+  const sqliteWasmDir = path.join(
+    workspaceRoot,
+    "packages",
+    "mojidata-api-sqlite-wasm",
+  )
+
+  test("browser and edge-safe facade entrypoints avoid Node-only imports", () => {
+    const banned = [
+      /^better-sqlite3$/u,
+      /^@mandel59\/mojidata-api-(better-sqlite3|node-sqlite)$/u,
+    ]
+    for (const subpath of [
+      "./app",
+      "./browser-client",
+      "./core",
+      "./hono",
+      "./worker-protocol",
+    ]) {
+      const entry = path.join(facadeDir, exportTarget(facadeDir, subpath, "require"))
+      const graph = collectStaticGraph(entry, "require")
+      assertNoBuiltinImports(subpath, graph.external)
+      assertNoExternalImports(subpath, graph.external, banned)
+    }
+  })
+
+  test("browser worker facade avoids native Node backends", () => {
+    const entry = path.join(
+      facadeDir,
+      exportTarget(facadeDir, "./browser-worker", "require"),
+    )
+    const graph = collectStaticGraph(entry, "require")
+    assertNoExternalImports("./browser-worker", graph.external, [
+      /^better-sqlite3$/u,
+      /^@mandel59\/mojidata-api-(better-sqlite3|node-sqlite)$/u,
+    ])
+  })
+
+  test("Node sqljs entrypoint does not import native sqlite backends", () => {
+    const entry = path.join(
+      facadeDir,
+      exportTarget(facadeDir, "./node-sqljs", "require"),
+    )
+    const graph = collectStaticGraph(entry, "require")
+    assertNoExternalImports("./node-sqljs", graph.external, [
+      /^better-sqlite3$/u,
+      /^@mandel59\/mojidata-api-(better-sqlite3|node-sqlite)$/u,
+    ])
+  })
+
+  test("sqlite-wasm OPFS public entrypoint is importable without private lib paths", () => {
+    const entry = path.join(
+      sqliteWasmDir,
+      exportTarget(sqliteWasmDir, "./opfs-sahpool", "import"),
+    )
+    const graph = collectStaticGraph(entry, "import")
+    assert.ok(graph.files.some((file) => file.endsWith("opfs-sahpool.js")))
+  })
+})

--- a/packages/mojidata-api/tests/entrypoints.test.ts
+++ b/packages/mojidata-api/tests/entrypoints.test.ts
@@ -36,8 +36,12 @@ describe('package entrypoints', () => {
       './core',
       './hono',
       './node',
+      './node-better-sqlite3',
+      './node-sqlite',
+      './node-sqljs',
       './runtime',
       './sqljs',
+      './worker-protocol',
     ])
   })
 
@@ -70,5 +74,18 @@ describe('package entrypoints', () => {
     assert.equal(typeof ivsCompat.createIvsListHandler, 'function')
     assert.equal(typeof variantsCompat.createMojidataVariantsHandler, 'function')
     assert.equal(typeof idsfindCompat.createIdsfindHandler, 'function')
+  })
+
+  test('declares target-specific entrypoints for bundled apps', async () => {
+    const [browserClient, workerProtocol, nodeSqljs] = await Promise.all([
+      import('@mandel59/mojidata-api/browser-client'),
+      import('@mandel59/mojidata-api/worker-protocol'),
+      import('@mandel59/mojidata-api/node-sqljs'),
+    ])
+
+    assert.equal(typeof browserClient.createMojidataApiWorkerClient, 'function')
+    assert.deepEqual(Object.keys(workerProtocol), [])
+    assert.equal(typeof nodeSqljs.createSqlJsDb, 'function')
+    assert.equal(typeof nodeSqljs.openDatabaseFromFile, 'function')
   })
 })

--- a/packages/mojidata-api/worker-protocol.ts
+++ b/packages/mojidata-api/worker-protocol.ts
@@ -1,0 +1,6 @@
+export type {
+  WorkerCall,
+  WorkerInit,
+  WorkerRequest,
+  WorkerResponse,
+} from "@mandel59/mojidata-api-runtime"

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,8 +980,10 @@ __metadata:
   resolution: "@mandel59/mojidata-api@workspace:packages/mojidata-api"
   dependencies:
     "@hono/node-server": "npm:^1.19.7"
+    "@mandel59/mojidata-api-better-sqlite3": "npm:^1.8.0"
     "@mandel59/mojidata-api-core": "npm:^1.8.0"
     "@mandel59/mojidata-api-hono": "npm:^1.8.0"
+    "@mandel59/mojidata-api-node-sqlite": "npm:^1.8.0"
     "@mandel59/mojidata-api-runtime": "npm:^1.8.0"
     "@mandel59/mojidata-api-sqljs": "npm:^1.8.0"
     "@types/node": "npm:^24.10.4"
@@ -991,8 +993,14 @@ __metadata:
     typescript: "npm:^5.9.3"
   peerDependencies:
     "@hono/node-server": ^1.19.7
+    "@mandel59/mojidata-api-better-sqlite3": ^1.8.0
+    "@mandel59/mojidata-api-node-sqlite": ^1.8.0
   peerDependenciesMeta:
     "@hono/node-server":
+      optional: true
+    "@mandel59/mojidata-api-better-sqlite3":
+      optional: true
+    "@mandel59/mojidata-api-node-sqlite":
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary

- Add documented bundler-safe `@mandel59/mojidata-api` facade entrypoints for browser, worker protocol, SQL.js Node, `better-sqlite3`, and `node:sqlite` targets.
- Expose stable runtime and sqlite-wasm public subpaths so `mojidata-web-app` does not need private `lib/*` imports.
- Add static entrypoint smoke tests to catch browser/Cloudflare-unsafe imports and validate the sqlite-wasm OPFS public path.
- Validate sqlite-wasm `idsfind.db` schemas as FTS5 and document the `@mandel59/idsdb-fts5` requirement.

## Validation

- `corepack yarn node --import tsx --test ./tests/*.test.ts` in `packages/mojidata-api`
- `corepack yarn node --import tsx --test ./tests/*.test.ts` in `packages/mojidata-api-sqlite-wasm`
- `corepack yarn install --immutable`

## Related Issues

Related: #29
Related: #32
Related: #34

## Notes

This branch is based on `cloudflare` because the local work was built on top of the current D1/API deployment branch.