### PR TITLE
Fix release publishing metadata

### DIFF
--- a/.changeset/fix-release-publishing-metadata.md
+++ b/.changeset/fix-release-publishing-metadata.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix release publishing metadata without changing package versions.

--- a/packages/idsdb-fts5/package.json
+++ b/packages/idsdb-fts5/package.json
@@ -18,8 +18,7 @@
   ],
   "scripts": {
     "prepare": "bash scripts/prepare",
-    "prepack": "yarn prepare",
-    "publish": "yarn prepare && yarn npm publish --access public"
+    "prepack": "yarn prepare"
   },
   "author": "Ryusei Yamaguchi",
   "license": "MIT"

--- a/packages/idsdb-utils/package.json
+++ b/packages/idsdb-utils/package.json
@@ -34,8 +34,7 @@
     "LICENSE.md"
   ],
   "scripts": {
-    "prepare": "tsc",
-    "publish": "yarn prepare && yarn npm publish --access public"
+    "prepare": "tsc"
   },
   "author": "Ryusei Yamaguchi",
   "license": "MIT",

--- a/packages/idsdb/package.json
+++ b/packages/idsdb/package.json
@@ -19,8 +19,7 @@
     "LICENSE.md"
   ],
   "scripts": {
-    "prepare": "bash scripts/prepare",
-    "publish": "yarn prepare && yarn npm publish --access public"
+    "prepare": "bash scripts/prepare"
   },
   "author": "Ryusei Yamaguchi",
   "license": "MIT",

--- a/packages/idstool/package.json
+++ b/packages/idstool/package.json
@@ -24,8 +24,7 @@
   "scripts": {
     "test": "yarn prepare && ava",
     "test:ci": "yarn prepare && ava",
-    "prepare": "tsc",
-    "publish": "yarn prepare && yarn npm publish --access public"
+    "prepare": "tsc"
   },
   "author": "Ryusei Yamaguchi",
   "license": "MIT",

--- a/packages/mojidata-api-better-sqlite3/package.json
+++ b/packages/mojidata-api-better-sqlite3/package.json
@@ -30,7 +30,6 @@
   "scripts": {
     "prepare": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && tsc",
     "prepare:test-deps": "yarn --cwd ../.. workspace @mandel59/mojidata run prepare && yarn --cwd ../.. workspace @mandel59/idsdb-fts5 run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-core run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-hono run prepare",
-    "publish": "yarn prepare && yarn npm publish --access public",
     "test": "yarn run prepare:test-deps && yarn prepare && node --import tsx --test ./tests/*.test.ts",
     "test:ci": "yarn run prepare:test-deps && yarn prepare && node --import tsx --test ./tests/*.test.ts"
   },

--- a/packages/mojidata-api-core/package.json
+++ b/packages/mojidata-api-core/package.json
@@ -28,8 +28,7 @@
     "LICENSE.md"
   ],
   "scripts": {
-    "prepare": "tsc",
-    "publish": "yarn prepare && yarn npm publish --access public"
+    "prepare": "tsc"
   },
   "author": "Ryusei Yamaguchi",
   "license": "MIT",

--- a/packages/mojidata-api-d1/package.json
+++ b/packages/mojidata-api-d1/package.json
@@ -30,8 +30,7 @@
   "scripts": {
     "prepare": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && tsc",
     "test": "yarn prepare && node --import tsx --test ./tests/*.test.ts",
-    "test:ci": "yarn prepare && node --import tsx --test ./tests/*.test.ts",
-    "publish": "yarn prepare && yarn npm publish --access public"
+    "test:ci": "yarn prepare && node --import tsx --test ./tests/*.test.ts"
   },
   "author": "Ryusei Yamaguchi",
   "license": "MIT",

--- a/packages/mojidata-api-hono/package.json
+++ b/packages/mojidata-api-hono/package.json
@@ -33,8 +33,7 @@
     "LICENSE.md"
   ],
   "scripts": {
-    "prepare": "tsc",
-    "publish": "yarn prepare && yarn npm publish --access public"
+    "prepare": "tsc"
   },
   "author": "Ryusei Yamaguchi",
   "license": "MIT",

--- a/packages/mojidata-api-node-sqlite/package.json
+++ b/packages/mojidata-api-node-sqlite/package.json
@@ -30,7 +30,6 @@
   "scripts": {
     "prepare": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && tsc",
     "prepare:test-deps": "yarn --cwd ../.. workspace @mandel59/mojidata run prepare && yarn --cwd ../.. workspace @mandel59/idsdb-fts5 run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-core run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-hono run prepare",
-    "publish": "yarn prepare && yarn npm publish --access public",
     "test": "yarn run prepare:test-deps && yarn prepare && node --import tsx --test ./tests/*.test.ts",
     "test:ci": "yarn run prepare:test-deps && yarn prepare && node --import tsx --test ./tests/*.test.ts"
   },

--- a/packages/mojidata-api-runtime/package.json
+++ b/packages/mojidata-api-runtime/package.json
@@ -38,8 +38,7 @@
     "LICENSE.md"
   ],
   "scripts": {
-    "prepare": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && tsc",
-    "publish": "yarn prepare && yarn npm publish --access public"
+    "prepare": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && tsc"
   },
   "author": "Ryusei Yamaguchi",
   "license": "MIT",

--- a/packages/mojidata-api-sqlite-wasm/package.json
+++ b/packages/mojidata-api-sqlite-wasm/package.json
@@ -47,8 +47,7 @@
     "prepare": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && ../../.yarn/sdks/typescript/bin/tsc",
     "prepare:test-deps": "(cd ../mojidata-api-core && ../../.yarn/sdks/typescript/bin/tsc) && (cd ../mojidata-api-runtime && node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && ../../.yarn/sdks/typescript/bin/tsc)",
     "test": "yarn run prepare:test-deps && yarn prepare && node --import tsx --test ./tests/*.test.ts",
-    "test:ci": "yarn run prepare:test-deps && yarn prepare && node --import tsx --test ./tests/*.test.ts",
-    "publish": "yarn prepare && yarn npm publish --access public"
+    "test:ci": "yarn run prepare:test-deps && yarn prepare && node --import tsx --test ./tests/*.test.ts"
   },
   "author": "Ryusei Yamaguchi",
   "license": "MIT",

--- a/packages/mojidata-api-sqljs/package.json
+++ b/packages/mojidata-api-sqljs/package.json
@@ -36,8 +36,7 @@
     "prepare": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && tsc",
     "prepare:test-deps": "yarn --cwd ../.. workspace @mandel59/mojidata run prepare && yarn --cwd ../.. workspace @mandel59/idsdb run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-core run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-hono run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-runtime run prepare",
     "test": "yarn run prepare:test-deps && yarn prepare && node --import tsx --test ./tests/*.test.ts",
-    "test:ci": "yarn run prepare:test-deps && yarn prepare && node --import tsx --test ./tests/*.test.ts",
-    "publish": "yarn prepare && yarn npm publish --access public"
+    "test:ci": "yarn run prepare:test-deps && yarn prepare && node --import tsx --test ./tests/*.test.ts"
   },
   "author": "Ryusei Yamaguchi",
   "license": "MIT",

--- a/packages/mojidata-api/package.json
+++ b/packages/mojidata-api/package.json
@@ -2,6 +2,11 @@
   "name": "@mandel59/mojidata-api",
   "version": "2.0.0",
   "description": "Compatibility facade package for mojidata-api split packages",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mandel59/mojidata.git",
+    "directory": "packages/mojidata-api"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -93,7 +98,6 @@
     "dev": "tsx watch ./server.ts",
     "prepare": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && tsc",
     "prepare:test-deps": "yarn --cwd ../.. workspace @mandel59/mojidata run prepare && yarn --cwd ../.. workspace @mandel59/idsdb run prepare && yarn --cwd ../.. workspace @mandel59/idsdb-fts5 run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-core run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-hono run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-runtime run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-sqljs run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-better-sqlite3 run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-node-sqlite run prepare",
-    "publish": "yarn prepare && yarn npm publish --access public",
     "test": "yarn run prepare:test-deps && yarn prepare && node --import tsx --test ./tests/*.test.ts",
     "test:ci": "yarn run prepare:test-deps && yarn prepare && node --import tsx --test ./tests/*.test.ts"
   },

--- a/packages/mojidata-cli/package.json
+++ b/packages/mojidata-cli/package.json
@@ -21,8 +21,7 @@
   "scripts": {
     "test": "yarn prepare && ava",
     "test:ci": "yarn prepare && ava",
-    "prepare": "tsc",
-    "publish": "yarn prepare && yarn npm publish --access public"
+    "prepare": "tsc"
   },
   "author": "Ryusei Yamaguchi",
   "license": "MIT",

--- a/packages/mojidata/package.json
+++ b/packages/mojidata/package.json
@@ -25,7 +25,6 @@
     "test": "ava",
     "test:ci": "ava",
     "prepare": "bash scripts/prepare",
-    "publish": "yarn prepare && yarn npm publish --access public",
     "update-ids-txt": "ts-node --transpile-only scripts/update-ids-txt.ts download.txt"
   },
   "author": "Ryusei Yamaguchi",

--- a/packages/react-mojidata-api/package.json
+++ b/packages/react-mojidata-api/package.json
@@ -21,7 +21,6 @@
   "scripts": {
     "prepare": "tsc",
     "prepare:test-deps": "yarn --cwd ../.. workspace @mandel59/mojidata run prepare && yarn --cwd ../.. workspace @mandel59/idsdb run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-core run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-sqljs run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-hono run prepare && yarn --cwd ../.. workspace @mandel59/mojidata-api-runtime run prepare",
-    "publish": "yarn prepare && yarn npm publish --access public",
     "test": "yarn run prepare:test-deps && yarn test:unit && yarn test:integration",
     "test:ci": "yarn run prepare:test-deps && yarn test:unit",
     "test:unit": "node --import tsx --test ./tests/*.test.tsx",


### PR DESCRIPTION
## Summary
- add repository metadata to `@mandel59/mojidata-api` so npm provenance validation matches the GitHub repository
- remove package-level `publish` lifecycle scripts that recursively run `yarn npm publish` during `changeset publish`
- keep package versions unchanged so the current release can continue publishing the versions from PR #26

## Verification
- `node -e "const fs=require('fs'); const files=process.argv.slice(1); for (const f of files) JSON.parse(fs.readFileSync(f,'utf8')); console.log(files.length+' package.json files parsed')" package.json packages/*/package.json`
- `corepack yarn ci:pack`

## Release notes
Before merging this PR and rerunning the Release workflow, the first publish for these new packages still needs to be completed manually:
- `@mandel59/mojidata-api-better-sqlite3@1.9.0`
- `@mandel59/mojidata-api-d1@1.9.0`
- `@mandel59/mojidata-api-node-sqlite@1.9.0`

After the first manual publish, future releases should use Trusted Publishing normally.