### PR TITLE
[codex] Optimize D1 full-field lookups

### DIFF
--- a/.changeset/tall-rivers-d1-indexes.md
+++ b/.changeset/tall-rivers-d1-indexes.md
@@ -1,0 +1,7 @@
+---
+"@mandel59/mojidata": patch
+"@mandel59/mojidata-api-core": patch
+"@mandel59/mojidata-cli": patch
+---
+
+Optimize mojidata full-field D1 lookup SQL to use index-friendly predicates for IDS, IVS, SVS, TGHB, MJIH, and KDPV data.

--- a/.changeset/tall-rivers-d1-indexes.md
+++ b/.changeset/tall-rivers-d1-indexes.md
@@ -5,3 +5,4 @@
 ---
 
 Optimize mojidata full-field D1 lookup SQL to use index-friendly predicates for IDS, IVS, SVS, TGHB, MJIH, and KDPV data.
+Include current IDS mirror and rotation operators in `ids_similar` lookups while keeping legacy aliases.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,61 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  prepare-db-cache:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NO_UPDATE_NOTIFIER: "1"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: yarn
+
+      - name: Restore mojidata build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/mojidata/dist
+            packages/mojidata/cache
+            packages/mojidata/resources
+          key: mojidata-${{ runner.os }}-${{ hashFiles('packages/mojidata/download.txt', 'packages/mojidata/package.json', 'packages/mojidata/scripts/**', 'packages/mojidata/build-data/unihan-tr38-properties.json') }}
+          restore-keys: |
+            mojidata-${{ runner.os }}-
+
+      - name: Restore idsdb build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/idsdb/idsfind.db
+            packages/idsdb/idsdecompose.db
+            packages/idsdb/.idsdb.input.sha256
+            packages/idsdb-fts5/idsfind.db
+            packages/idsdb-fts5/idsdecompose.db
+            packages/idsdb-fts5/.idsdb-fts5.input.sha256
+          key: idsdb-${{ runner.os }}-${{ hashFiles('packages/mojidata/download.txt', 'packages/mojidata/package.json', 'packages/mojidata/scripts/**', 'packages/mojidata/build-data/unihan-tr38-properties.json', 'packages/idsdb/package.json', 'packages/idsdb/tsconfig.json', 'packages/idsdb/prepare.ts', 'packages/idsdb/scripts/**', 'packages/idsdb-fts5/package.json', 'packages/idsdb-fts5/scripts/**', 'packages/idsdb-utils/package.json', 'packages/idsdb-utils/tsconfig.json', 'packages/idsdb-utils/index.ts', 'packages/idsdb-utils/node.ts', 'packages/idsdb-utils/lib/**') }}
+          restore-keys: |
+            idsdb-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: corepack yarn install --immutable
+
+      - name: Prepare mojidata and IDS database artifacts
+        run: |
+          corepack yarn build:idsdb-stack
+          corepack yarn workspace @mandel59/idsdb-fts5 run prepare
+
   release:
     runs-on: ubuntu-latest
+    needs: prepare-db-cache
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,8 +11,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prepare-db-cache:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NO_UPDATE_NOTIFIER: "1"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - name: Restore mojidata build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/mojidata/dist
+            packages/mojidata/cache
+            packages/mojidata/resources
+          key: mojidata-${{ runner.os }}-${{ hashFiles('packages/mojidata/download.txt', 'packages/mojidata/package.json', 'packages/mojidata/scripts/**', 'packages/mojidata/build-data/unihan-tr38-properties.json') }}
+          restore-keys: |
+            mojidata-${{ runner.os }}-
+
+      - name: Restore idsdb build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/idsdb/idsfind.db
+            packages/idsdb/idsdecompose.db
+            packages/idsdb/.idsdb.input.sha256
+            packages/idsdb-fts5/idsfind.db
+            packages/idsdb-fts5/idsdecompose.db
+            packages/idsdb-fts5/.idsdb-fts5.input.sha256
+          key: idsdb-${{ runner.os }}-${{ hashFiles('packages/mojidata/download.txt', 'packages/mojidata/package.json', 'packages/mojidata/scripts/**', 'packages/mojidata/build-data/unihan-tr38-properties.json', 'packages/idsdb/package.json', 'packages/idsdb/tsconfig.json', 'packages/idsdb/prepare.ts', 'packages/idsdb/scripts/**', 'packages/idsdb-fts5/package.json', 'packages/idsdb-fts5/scripts/**', 'packages/idsdb-utils/package.json', 'packages/idsdb-utils/tsconfig.json', 'packages/idsdb-utils/index.ts', 'packages/idsdb-utils/node.ts', 'packages/idsdb-utils/lib/**') }}
+          restore-keys: |
+            idsdb-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: corepack yarn install --immutable
+
+      - name: Prepare mojidata and IDS database artifacts
+        run: |
+          corepack yarn build:idsdb-stack
+          corepack yarn workspace @mandel59/idsdb-fts5 run prepare
+
   validate:
     runs-on: ubuntu-latest
+    needs: prepare-db-cache
     permissions:
       contents: read
     env:

--- a/packages/mojidata-api-better-sqlite3/tests/better-sqlite3-runtime.test.ts
+++ b/packages/mojidata-api-better-sqlite3/tests/better-sqlite3-runtime.test.ts
@@ -14,4 +14,18 @@ describe("createBetterSqlite3Db", () => {
     assert.match(mojidata ?? "", /"UCS":"U\+6F22"/)
     assert.ok(idsfind.includes("信"))
   })
+
+  test("returns ids_similar entries for current IDS mirror and rotation operators", async () => {
+    const db = createBetterSqlite3Db()
+
+    const mirror = JSON.parse((await db.getMojidataJson("卍", ["ids_similar"])) ?? "{}")
+    const rotation = JSON.parse((await db.getMojidataJson("了", ["ids_similar"])) ?? "{}")
+
+    assert.deepEqual(mirror.ids_similar, [
+      { UCS: "卐", IDS: "⿾卍", source: "GT" },
+    ])
+    assert.deepEqual(rotation.ids_similar, [
+      { UCS: "𠄏", IDS: "⿿了", source: "GTP" },
+    ])
+  })
 })

--- a/packages/mojidata-api-better-sqlite3/tests/better-sqlite3-runtime.test.ts
+++ b/packages/mojidata-api-better-sqlite3/tests/better-sqlite3-runtime.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict"
 import { describe, test } from "node:test"
 
-import { createBetterSqlite3Db } from "../index"
+import { runMojidataApiConformanceTests } from "../../mojidata-api/tests/api-conformance"
+import { createBetterSqlite3App, createBetterSqlite3Db } from "../index"
 
 describe("createBetterSqlite3Db", () => {
   test("supports better-sqlite3 as an explicit native backend", async () => {
@@ -29,3 +30,5 @@ describe("createBetterSqlite3Db", () => {
     ])
   })
 })
+
+runMojidataApiConformanceTests("better-sqlite3 API conformance", () => createBetterSqlite3App())

--- a/packages/mojidata-api-core/lib/mojidata-api-db-sql.ts
+++ b/packages/mojidata-api-core/lib/mojidata-api-db-sql.ts
@@ -19,7 +19,7 @@ const ivsListQuery = `
     collection,
     code
   FROM ivs
-  WHERE IVS GLOB @ucs || '*'
+  WHERE IVS >= @ucs AND IVS < char(unicode(@ucs) + 1)
 `
 
 // Copied from `packages/mojidata-cli/bin/mojidata-variants.ts` (better-sqlite3),

--- a/packages/mojidata-api-core/lib/query-expressions.ts
+++ b/packages/mojidata-api-core/lib/query-expressions.ts
@@ -18,7 +18,7 @@ export const queryExpressions = [
   ],
   [
     'ids_similar',
-    `(SELECT json_group_array(json_object('UCS', ids.UCS, 'IDS', ids.IDS, 'source', ids.source)) FROM ids WHERE ids.IDS glob ('[〾↔↷]' || @ucs))`,
+    `(SELECT json_group_array(json_object('UCS', ids.UCS, 'IDS', ids.IDS, 'source', ids.source)) FROM ids WHERE ids.IDS IN ('〾' || @ucs, '↔' || @ucs, '↷' || @ucs))`,
   ],
   [
     'ids_comment',
@@ -30,7 +30,8 @@ export const queryExpressions = [
         'char', ivs.IVS,
         'IVS', printf('%04X_%04X', unicode(ivs.IVS), unicode(substr(ivs.IVS, 2))),
         'collection', ivs.collection,
-        'code', ivs.code)) FROM ivs WHERE ivs.IVS glob (@ucs || '*'))`,
+        'code', ivs.code)) FROM ivs
+      WHERE ivs.IVS >= @ucs AND ivs.IVS < char(unicode(@ucs) + 1))`,
   ],
   [
     'ivs_duplicate',
@@ -43,7 +44,9 @@ export const queryExpressions = [
       code))
     from ivs as ivs1
       join ivs as ivs2 using (collection, code)
-    where (ivs1.IVS <> ivs2.IVS) and (ivs1.IVS glob (@ucs || '*')))`,
+    where (ivs1.IVS <> ivs2.IVS)
+      and ivs1.IVS >= @ucs
+      and ivs1.IVS < char(unicode(@ucs) + 1))`,
   ],
   [
     'svs_cjkci',
@@ -54,7 +57,7 @@ export const queryExpressions = [
             'CJKCI_char', CJKCI,
             'CJKCI', printf('U+%04X', unicode(CJKCI))))
         FROM svs_cjkci
-        WHERE (SVS glob @ucs || '*') OR (CJKCI glob @ucs || '*'))`,
+        WHERE (SVS >= @ucs AND SVS < char(unicode(@ucs) + 1)) OR CJKCI = @ucs)`,
   ],
   [
     'unihan',
@@ -153,7 +156,8 @@ export const queryExpressions = [
             )) FROM tghb_variants AS v WHERE v.规范字 = tghb.规范字)
         ))
         FROM tghb
-        WHERE @ucs = tghb.规范字 OR @ucs IN (SELECT v.异体字 FROM tghb_variants AS v WHERE v.规范字 = tghb.规范字)
+        WHERE tghb.规范字 = @ucs
+          OR tghb.规范字 IN (SELECT v.规范字 FROM tghb_variants AS v WHERE v.异体字 = @ucs)
     )`,
   ],
   [
@@ -233,16 +237,26 @@ export const queryExpressions = [
       '国語研URL', 国語研URL,
       '備考', 備考
     ))
-    FROM mjih WHERE @ucs = mjih.文字 OR @ucs = mjih.字母 OR @ucs IN (SELECT 音価 FROM mjih_phonetic AS p WHERE p.MJ文字図形名 = mjih.MJ文字図形名))`,
+    FROM mjih
+    WHERE MJ文字図形名 IN (
+      SELECT MJ文字図形名 FROM mjih WHERE 文字 = @ucs
+      UNION
+      SELECT MJ文字図形名 FROM mjih WHERE 字母 = @ucs
+      UNION
+      SELECT MJ文字図形名 FROM mjih_phonetic WHERE 音価 = @ucs
+    ))`,
   ],
   [
     'kdpv',
     `(
         SELECT json_group_object(rel, json(cs)) FROM (
             SELECT rel, json_group_array(c) AS cs FROM (
-                SELECT DISTINCT rel, object AS c FROM kdpv WHERE subject glob @ucs || '*'
+                SELECT DISTINCT rel, object AS c FROM kdpv
+                WHERE subject >= @ucs AND subject < char(unicode(@ucs) + 1)
                 UNION
-                SELECT DISTINCT ifnull(rev, '~' || kdpv.rel) AS rel, subject AS c FROM kdpv LEFT JOIN kdpv_rels ON kdpv_rels.rel = kdpv.rel WHERE object glob @ucs || '*'
+                SELECT DISTINCT ifnull(rev, '~' || kdpv.rel) AS rel, subject AS c
+                FROM kdpv LEFT JOIN kdpv_rels ON kdpv_rels.rel = kdpv.rel
+                WHERE object >= @ucs AND object < char(unicode(@ucs) + 1)
             )
             GROUP BY rel
         )

--- a/packages/mojidata-api-core/lib/query-expressions.ts
+++ b/packages/mojidata-api-core/lib/query-expressions.ts
@@ -18,7 +18,7 @@ export const queryExpressions = [
   ],
   [
     'ids_similar',
-    `(SELECT json_group_array(json_object('UCS', ids.UCS, 'IDS', ids.IDS, 'source', ids.source)) FROM ids WHERE ids.IDS IN ('〾' || @ucs, '↔' || @ucs, '↷' || @ucs))`,
+    `(SELECT json_group_array(json_object('UCS', ids.UCS, 'IDS', ids.IDS, 'source', ids.source)) FROM ids WHERE ids.IDS IN ('〾' || @ucs, '⿾' || @ucs, '⿿' || @ucs, '↔' || @ucs, '↷' || @ucs))`,
   ],
   [
     'ids_comment',

--- a/packages/mojidata-api-d1-worker/wrangler.jsonc
+++ b/packages/mojidata-api-d1-worker/wrangler.jsonc
@@ -13,13 +13,13 @@
   "d1_databases": [
     {
       "binding": "MOJIDATA_DB",
-      "database_name": "mojidata-api-d1-mojidata-20260503-bg",
-      "database_id": "7d7a62e6-bc66-4c83-8716-ceab92fb972d"
+      "database_name": "mojidata-api-d1-mojidata-20260503-bg-20260504-d1-indexes",
+      "database_id": "54a92b59-a50b-41ce-a397-29353adfac0a"
     },
     {
       "binding": "IDSFIND_DB",
-      "database_name": "mojidata-api-d1-idsfind-20260503-bg",
-      "database_id": "950b99cd-dc7f-451f-b7fe-2f01385fb3df"
+      "database_name": "mojidata-api-d1-idsfind-20260503-bg-20260504-d1-indexes",
+      "database_id": "18e0c4f7-006c-474c-87e2-a00de91bec98"
     }
   ],
   "env": {

--- a/packages/mojidata-api-d1/tests/d1-app.test.ts
+++ b/packages/mojidata-api-d1/tests/d1-app.test.ts
@@ -218,6 +218,16 @@ describe("createD1App", () => {
     assert.ok(mojidataDb.preparedSql.some((sql) => sql.includes("SELECT json_object('char'")))
     assert.ok(mojidataDb.preparedSql.some((sql) => sql.includes("FROM ivs")))
     assert.ok(idsfindDb.preparedSql.some((sql) => sql.includes("from idsfind_fts")))
+
+    const fullFieldSql =
+      mojidataDb.preparedSql.find((sql) => sql.startsWith("SELECT json_object('char'")) ?? ""
+    assert.match(fullFieldSql, /ids\.IDS IN \('〾' \|\| \?1, '↔' \|\| \?1, '↷' \|\| \?1\)/)
+    assert.match(fullFieldSql, /ivs\.IVS >= \?1 AND ivs\.IVS < char\(unicode\(\?1\) \+ 1\)/)
+    assert.match(fullFieldSql, /SVS >= \?1 AND SVS < char\(unicode\(\?1\) \+ 1\)/)
+    assert.match(fullFieldSql, /SELECT MJ文字図形名 FROM mjih_phonetic WHERE 音価 = \?1/)
+    assert.match(fullFieldSql, /subject >= \?1 AND subject < char\(unicode\(\?1\) \+ 1\)/)
+    assert.match(fullFieldSql, /object >= \?1 AND object < char\(unicode\(\?1\) \+ 1\)/)
+    assert.doesNotMatch(fullFieldSql, /glob\s+\(?\?1\s*\|\|\s*'\*'/i)
   })
 
   test("can be created from standard Cloudflare D1 binding names", async () => {

--- a/packages/mojidata-api-d1/tests/d1-app.test.ts
+++ b/packages/mojidata-api-d1/tests/d1-app.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import { describe, test } from "node:test"
 
+import { runMojidataApiConformanceTests } from "../../mojidata-api/tests/api-conformance"
 import { createD1App, createD1AppFromEnv, createD1FetchHandler } from "../index"
 import type {
   D1DatabaseLike,
@@ -60,13 +61,31 @@ function createFakeMojidataDb() {
     if (normalizedSql.startsWith("SELECT json_object('char', ?1,'UCS'")) {
       assert.equal(mode, "first")
       assert.deepEqual(values, ["漢"])
-      return { vs: JSON.stringify({ UCS: "U+6F22" }) }
+      return { vs: JSON.stringify({ char: "漢", UCS: "U+6F22" }) }
     }
 
     if (normalizedSql.startsWith("SELECT json_object('UCS'")) {
       assert.equal(mode, "first")
       assert.deepEqual(values, ["漢"])
       return { vs: JSON.stringify({ UCS: "U+6F22" }) }
+    }
+
+    if (normalizedSql.startsWith("SELECT json_object('ids_similar'")) {
+      assert.equal(mode, "first")
+      if (values[0] === "卍") {
+        return {
+          vs: JSON.stringify({
+            ids_similar: [{ UCS: "卐", IDS: "⿾卍", source: "GT" }],
+          }),
+        }
+      }
+      if (values[0] === "了") {
+        return {
+          vs: JSON.stringify({
+            ids_similar: [{ UCS: "𠄏", IDS: "⿿了", source: "GTP" }],
+          }),
+        }
+      }
     }
 
     if (normalizedSql.includes("FROM chars")) {
@@ -81,11 +100,13 @@ function createFakeMojidataDb() {
       )
     ) {
       assert.equal(mode, "run")
-      assert.deepEqual(values, ["漢"])
+      assert.ok(values[0] === "漢" || values[0] === "一")
+      const base = values[0] === "一" ? "一" : "漢"
+      const unicode = values[0] === "一" ? "4E00 E0100" : "6F22 E0100"
       return [
         {
-          IVS: "漢󠄀",
-          unicode: "6F22 E0100",
+          IVS: `${base}󠄀`,
+          unicode,
           collection: "ExampleCollection",
           code: "CID+1234",
         },
@@ -174,6 +195,7 @@ describe("createD1App", () => {
       assert.deepEqual(json, {
         query: { char: "漢" },
         results: {
+          char: "漢",
           UCS: "U+6F22",
           unihan_rs: {
             kRSAdobe_Japan1_6: null,
@@ -272,3 +294,10 @@ describe("createD1App", () => {
     })
   })
 })
+
+runMojidataApiConformanceTests("D1 API conformance", () =>
+  createD1App({
+    mojidataDb: createFakeMojidataDb(),
+    idsfindDb: createFakeIdsfindDb(),
+  }),
+)

--- a/packages/mojidata-api-d1/tests/d1-app.test.ts
+++ b/packages/mojidata-api-d1/tests/d1-app.test.ts
@@ -221,7 +221,7 @@ describe("createD1App", () => {
 
     const fullFieldSql =
       mojidataDb.preparedSql.find((sql) => sql.startsWith("SELECT json_object('char'")) ?? ""
-    assert.match(fullFieldSql, /ids\.IDS IN \('〾' \|\| \?1, '↔' \|\| \?1, '↷' \|\| \?1\)/)
+    assert.match(fullFieldSql, /ids\.IDS IN \('〾' \|\| \?1, '⿾' \|\| \?1, '⿿' \|\| \?1, '↔' \|\| \?1, '↷' \|\| \?1\)/)
     assert.match(fullFieldSql, /ivs\.IVS >= \?1 AND ivs\.IVS < char\(unicode\(\?1\) \+ 1\)/)
     assert.match(fullFieldSql, /SVS >= \?1 AND SVS < char\(unicode\(\?1\) \+ 1\)/)
     assert.match(fullFieldSql, /SELECT MJ文字図形名 FROM mjih_phonetic WHERE 音価 = \?1/)

--- a/packages/mojidata-api-node-sqlite/tests/node-sqlite-runtime.test.ts
+++ b/packages/mojidata-api-node-sqlite/tests/node-sqlite-runtime.test.ts
@@ -14,4 +14,18 @@ describe("createNodeSqliteDb", () => {
     assert.match(mojidata ?? "", /"UCS":"U\+6F22"/)
     assert.ok(idsfind.includes("信"))
   })
+
+  test("returns ids_similar entries for current IDS mirror and rotation operators", async () => {
+    const db = createNodeSqliteDb()
+
+    const mirror = JSON.parse((await db.getMojidataJson("卍", ["ids_similar"])) ?? "{}")
+    const rotation = JSON.parse((await db.getMojidataJson("了", ["ids_similar"])) ?? "{}")
+
+    assert.deepEqual(mirror.ids_similar, [
+      { UCS: "卐", IDS: "⿾卍", source: "GT" },
+    ])
+    assert.deepEqual(rotation.ids_similar, [
+      { UCS: "𠄏", IDS: "⿿了", source: "GTP" },
+    ])
+  })
 })

--- a/packages/mojidata-api-node-sqlite/tests/node-sqlite-runtime.test.ts
+++ b/packages/mojidata-api-node-sqlite/tests/node-sqlite-runtime.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict"
 import { describe, test } from "node:test"
 
-import { createNodeSqliteDb } from "../index"
+import { runMojidataApiConformanceTests } from "../../mojidata-api/tests/api-conformance"
+import { createNodeSqliteApp, createNodeSqliteDb } from "../index"
 
 describe("createNodeSqliteDb", () => {
   test("supports node:sqlite as an explicit native backend", async () => {
@@ -29,3 +30,5 @@ describe("createNodeSqliteDb", () => {
     ])
   })
 })
+
+runMojidataApiConformanceTests("node:sqlite API conformance", () => createNodeSqliteApp())

--- a/packages/mojidata-api-sqlite-wasm/tests/sqlite-wasm-executor.test.ts
+++ b/packages/mojidata-api-sqlite-wasm/tests/sqlite-wasm-executor.test.ts
@@ -3,6 +3,8 @@ import { describe, test } from "node:test"
 
 import sqlite3InitModule from "@sqlite.org/sqlite-wasm"
 
+import appModule from "../../mojidata-api-hono/lib/app.ts"
+import conformanceModule from "../../mojidata-api/tests/api-conformance.ts"
 import {
   createSqliteWasmExecutor,
   createSqliteWasmDb,
@@ -17,6 +19,10 @@ import {
   type SqliteWasmIdsfindSchemaDatabase,
   type SqliteWasmSAHPoolUtil,
 } from "../index.js"
+
+const { createApp } = appModule as typeof import("../../mojidata-api-hono/lib/app")
+const { runMojidataApiConformanceTests } =
+  conformanceModule as typeof import("../../mojidata-api/tests/api-conformance")
 
 describe("createSqliteWasmExecutor", () => {
   test("supports positional and named parameters", async () => {
@@ -83,6 +89,27 @@ describe("createSqliteWasmDb", () => {
       idsfindDb.close()
     }
   })
+})
+
+runMojidataApiConformanceTests("sqlite-wasm API conformance", async () => {
+  const sqlite3 = await sqlite3InitModule()
+  const mojidataDb = new sqlite3.oo1.DB(":memory:")
+  const idsfindDb = new sqlite3.oo1.DB(":memory:")
+
+  mojidataDb.exec("CREATE TABLE ids (UCS TEXT NOT NULL, source TEXT NOT NULL, IDS TEXT NOT NULL)")
+  mojidataDb.exec("INSERT INTO ids (UCS, source, IDS) VALUES ('卐', 'GT', '⿾卍'), ('𠄏', 'GTP', '⿿了')")
+  mojidataDb.exec("CREATE TABLE ivs (IVS TEXT NOT NULL, collection TEXT NOT NULL, code TEXT NOT NULL)")
+  mojidataDb.exec("INSERT INTO ivs (IVS, collection, code) VALUES ('一󠄀', 'ExampleCollection', 'CID+1200')")
+
+  idsfindDb.exec("CREATE TABLE idsfind (UCS TEXT NOT NULL, IDS_tokens TEXT NOT NULL)")
+  idsfindDb.exec("CREATE VIRTUAL TABLE idsfind_fts USING fts5(IDS_tokens)")
+  idsfindDb.exec("INSERT INTO idsfind (rowid, UCS, IDS_tokens) VALUES (1, '信', '⿰ 亻 言')")
+  idsfindDb.exec("INSERT INTO idsfind_fts (rowid, IDS_tokens) VALUES (1, '⿰ 亻 言')")
+
+  return createApp(createSqliteWasmDb({
+    getMojidataDb: async () => createSqliteWasmExecutor(mojidataDb),
+    getIdsfindDb: async () => createSqliteWasmExecutor(idsfindDb),
+  }))
 })
 
 describe("installMojidataSqliteWasmFunctions", () => {

--- a/packages/mojidata-api-sqlite-wasm/tests/sqlite-wasm-executor.test.ts
+++ b/packages/mojidata-api-sqlite-wasm/tests/sqlite-wasm-executor.test.ts
@@ -5,6 +5,7 @@ import sqlite3InitModule from "@sqlite.org/sqlite-wasm"
 
 import {
   createSqliteWasmExecutor,
+  createSqliteWasmDb,
   createSqliteWasmDbFromOpfsSAHPool,
   installMojidataSqliteWasmFunctions,
   isOpfsSAHPoolSupported,
@@ -50,6 +51,36 @@ describe("createSqliteWasmExecutor", () => {
       assert.equal(await executor.queryOne("SELECT 1 WHERE 0"), null)
     } finally {
       db.close()
+    }
+  })
+})
+
+describe("createSqliteWasmDb", () => {
+  test("returns ids_similar entries for current IDS mirror and rotation operators", async () => {
+    const sqlite3 = await sqlite3InitModule()
+    const mojidataDb = new sqlite3.oo1.DB(":memory:")
+    const idsfindDb = new sqlite3.oo1.DB(":memory:")
+    try {
+      mojidataDb.exec("CREATE TABLE ids (UCS TEXT NOT NULL, source TEXT NOT NULL, IDS TEXT NOT NULL)")
+      mojidataDb.exec("INSERT INTO ids (UCS, source, IDS) VALUES ('卐', 'GT', '⿾卍'), ('𠄏', 'GTP', '⿿了')")
+
+      const db = createSqliteWasmDb({
+        getMojidataDb: async () => createSqliteWasmExecutor(mojidataDb),
+        getIdsfindDb: async () => createSqliteWasmExecutor(idsfindDb),
+      })
+
+      const mirror = JSON.parse((await db.getMojidataJson("卍", ["ids_similar"])) ?? "{}")
+      const rotation = JSON.parse((await db.getMojidataJson("了", ["ids_similar"])) ?? "{}")
+
+      assert.deepEqual(mirror.ids_similar, [
+        { UCS: "卐", IDS: "⿾卍", source: "GT" },
+      ])
+      assert.deepEqual(rotation.ids_similar, [
+        { UCS: "𠄏", IDS: "⿿了", source: "GTP" },
+      ])
+    } finally {
+      mojidataDb.close()
+      idsfindDb.close()
     }
   })
 })

--- a/packages/mojidata-api-sqljs/tests/sqljs-runtime.test.ts
+++ b/packages/mojidata-api-sqljs/tests/sqljs-runtime.test.ts
@@ -14,4 +14,18 @@ describe("createSqlJsDb", () => {
     assert.match(mojidata ?? "", /"UCS":"U\+6F22"/)
     assert.ok(idsfind.includes("信"))
   })
+
+  test("returns ids_similar entries for current IDS mirror and rotation operators", async () => {
+    const db = createSqlJsDb()
+
+    const mirror = JSON.parse((await db.getMojidataJson("卍", ["ids_similar"])) ?? "{}")
+    const rotation = JSON.parse((await db.getMojidataJson("了", ["ids_similar"])) ?? "{}")
+
+    assert.deepEqual(mirror.ids_similar, [
+      { UCS: "卐", IDS: "⿾卍", source: "GT" },
+    ])
+    assert.deepEqual(rotation.ids_similar, [
+      { UCS: "𠄏", IDS: "⿿了", source: "GTP" },
+    ])
+  })
 })

--- a/packages/mojidata-api-sqljs/tests/sqljs-runtime.test.ts
+++ b/packages/mojidata-api-sqljs/tests/sqljs-runtime.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict"
 import { describe, test } from "node:test"
 
-import { createSqlJsDb } from "../index"
+import { runMojidataApiConformanceTests } from "../../mojidata-api/tests/api-conformance"
+import { createSqlJsApp, createSqlJsDb } from "../index"
 
 describe("createSqlJsDb", () => {
   test("supports sql.js as an explicit backend package", async () => {
@@ -29,3 +30,5 @@ describe("createSqlJsDb", () => {
     ])
   })
 })
+
+runMojidataApiConformanceTests("sql.js API conformance", () => createSqlJsApp())

--- a/packages/mojidata-api-sqljs/tsconfig.json
+++ b/packages/mojidata-api-sqljs/tsconfig.json
@@ -11,5 +11,5 @@
     "moduleResolution": "node",
     "lib": ["ES2020", "DOM"]
   },
-  "exclude": ["dist"]
+  "exclude": ["dist", "tests"]
 }

--- a/packages/mojidata-api/tests/api-conformance.test.ts
+++ b/packages/mojidata-api/tests/api-conformance.test.ts
@@ -1,0 +1,4 @@
+import { createNodeApp } from '../node'
+import { runMojidataApiConformanceTests } from './api-conformance'
+
+runMojidataApiConformanceTests('default Node API conformance', () => createNodeApp())

--- a/packages/mojidata-api/tests/api-conformance.ts
+++ b/packages/mojidata-api/tests/api-conformance.ts
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+type QueryValue = string | number | boolean | null | undefined
+type Query = Record<string, QueryValue | QueryValue[]>
+
+export type MojidataApiTestApp = {
+  fetch(request: Request): Response | Promise<Response>
+}
+
+export type CreateMojidataApiTestApp = () =>
+  | MojidataApiTestApp
+  | Promise<MojidataApiTestApp>
+
+function buildUrl(pathname: string, query: Query = {}) {
+  const url = new URL(pathname, 'http://mojidata-api.test')
+  for (const [key, rawValue] of Object.entries(query)) {
+    if (Array.isArray(rawValue)) {
+      for (const value of rawValue) {
+        if (value === undefined || value === null) continue
+        url.searchParams.append(key, String(value))
+      }
+      continue
+    }
+    if (rawValue === undefined || rawValue === null) continue
+    url.searchParams.set(key, String(rawValue))
+  }
+  return url
+}
+
+async function fetchJson(
+  app: MojidataApiTestApp,
+  pathname: string,
+  query?: Query,
+): Promise<{ response: Response; json: any }> {
+  const response = await app.fetch(new Request(buildUrl(pathname, query)))
+  const text = await response.text()
+  return {
+    response,
+    json: text.length > 0 ? JSON.parse(text) : null,
+  }
+}
+
+function assertJsonResponse(response: Response) {
+  assert.equal(response.status, 200)
+  assert.ok(
+    (response.headers.get('content-type') ?? '').includes('application/json'),
+  )
+  assert.equal(response.headers.get('access-control-allow-origin'), '*')
+}
+
+function assertIncludesRecord<T extends Record<string, unknown>>(
+  rows: unknown,
+  expected: T,
+) {
+  assert.ok(Array.isArray(rows))
+  assert.ok(
+    rows.some((row) =>
+      row &&
+      typeof row === 'object' &&
+      Object.entries(expected).every(
+        ([key, value]) => (row as Record<string, unknown>)[key] === value,
+      ),
+    ),
+    `expected rows to include ${JSON.stringify(expected)}, got ${JSON.stringify(rows)}`,
+  )
+}
+
+export function runMojidataApiConformanceTests(
+  name: string,
+  createApp: CreateMojidataApiTestApp,
+) {
+  describe(name, () => {
+    let appPromise: Promise<MojidataApiTestApp> | undefined
+    const getApp = () => {
+      appPromise ??= Promise.resolve(createApp())
+      return appPromise
+    }
+
+    test('serves selected mojidata fields', async () => {
+      const { response, json } = await fetchJson(await getApp(), '/api/v1/mojidata', {
+        char: '漢',
+        select: ['char', 'UCS'],
+      })
+
+      assertJsonResponse(response)
+      assert.deepEqual(json.query, { char: '漢', select: ['char', 'UCS'] })
+      assert.deepEqual(json.results, { char: '漢', UCS: 'U+6F22' })
+    })
+
+    test('serves ids_similar entries for current IDS mirror and rotation operators', async () => {
+      const mirror = await fetchJson(await getApp(), '/api/v1/mojidata', {
+        char: '卍',
+        select: 'ids_similar',
+      })
+      const rotation = await fetchJson(await getApp(), '/api/v1/mojidata', {
+        char: '了',
+        select: 'ids_similar',
+      })
+
+      assertJsonResponse(mirror.response)
+      assert.deepEqual(mirror.json.query, { char: '卍', select: ['ids_similar'] })
+      assertIncludesRecord(mirror.json.results.ids_similar, {
+        UCS: '卐',
+        IDS: '⿾卍',
+        source: 'GT',
+      })
+
+      assertJsonResponse(rotation.response)
+      assert.deepEqual(rotation.json.query, { char: '了', select: ['ids_similar'] })
+      assertIncludesRecord(rotation.json.results.ids_similar, {
+        UCS: '𠄏',
+        IDS: '⿿了',
+        source: 'GTP',
+      })
+    })
+
+    test('serves IVS list results', async () => {
+      const { response, json } = await fetchJson(await getApp(), '/api/v1/ivs-list', {
+        char: '一',
+      })
+
+      assertJsonResponse(response)
+      assert.deepEqual(json.query, { char: '一' })
+      assert.ok(Array.isArray(json.results))
+      assert.ok(json.results.length > 0)
+      assert.equal(typeof json.results[0].IVS, 'string')
+      assert.equal(typeof json.results[0].unicode, 'string')
+      assert.equal(typeof json.results[0].collection, 'string')
+      assert.equal(typeof json.results[0].code, 'string')
+      assert.ok(json.results[0].IVS.startsWith('一'))
+      assert.match(json.results[0].unicode, /^4E00 /u)
+    })
+
+    test('serves idsfind results', async () => {
+      const { response, json } = await fetchJson(await getApp(), '/api/v1/idsfind', {
+        ids: '⿰亻言',
+        limit: 20,
+      })
+
+      assertJsonResponse(response)
+      assert.deepEqual(json.query, { ids: ['⿰亻言'], whole: [], limit: 20 })
+      assert.ok(Array.isArray(json.results))
+      assert.ok(json.results.includes('信'))
+    })
+  })
+}

--- a/packages/mojidata-api/tests/mojidata-api-db-sql.test.ts
+++ b/packages/mojidata-api/tests/mojidata-api-db-sql.test.ts
@@ -224,7 +224,7 @@ describe('createSqlApiDb', () => {
     await db.getMojidataJson('漢', [])
 
     const sql = mojidata.queryOneCalls[0]?.sql ?? ''
-    assert.match(sql, /ids\.IDS IN \('〾' \|\| @ucs, '↔' \|\| @ucs, '↷' \|\| @ucs\)/)
+    assert.match(sql, /ids\.IDS IN \('〾' \|\| @ucs, '⿾' \|\| @ucs, '⿿' \|\| @ucs, '↔' \|\| @ucs, '↷' \|\| @ucs\)/)
     assert.match(sql, /ivs\.IVS >= @ucs AND ivs\.IVS < char\(unicode\(@ucs\) \+ 1\)/)
     assert.match(sql, /SVS >= @ucs AND SVS < char\(unicode\(@ucs\) \+ 1\)/)
     assert.match(sql, /tghb\.规范字 IN \(SELECT v\.规范字 FROM tghb_variants AS v WHERE v\.异体字 = @ucs\)/)

--- a/packages/mojidata-api/tests/mojidata-api-db-sql.test.ts
+++ b/packages/mojidata-api/tests/mojidata-api-db-sql.test.ts
@@ -210,4 +210,27 @@ describe('createSqlApiDb', () => {
     assert.match(sql, /FROM unihan_value_ref/)
     assert.doesNotMatch(sql, /unihan\.value glob|FROM unihan\s/)
   })
+
+  test('getMojidataJson emits index-friendly full-field lookup predicates', async () => {
+    const mojidata = createRecordingExecutor({
+      queryOne: async () => ({ vs: '{}' }),
+    })
+    const idsfind = createRecordingExecutor()
+    const db = createSqlApiDb({
+      getMojidataDb: async () => mojidata.executor,
+      getIdsfindDb: async () => idsfind.executor,
+    })
+
+    await db.getMojidataJson('漢', [])
+
+    const sql = mojidata.queryOneCalls[0]?.sql ?? ''
+    assert.match(sql, /ids\.IDS IN \('〾' \|\| @ucs, '↔' \|\| @ucs, '↷' \|\| @ucs\)/)
+    assert.match(sql, /ivs\.IVS >= @ucs AND ivs\.IVS < char\(unicode\(@ucs\) \+ 1\)/)
+    assert.match(sql, /SVS >= @ucs AND SVS < char\(unicode\(@ucs\) \+ 1\)/)
+    assert.match(sql, /tghb\.规范字 IN \(SELECT v\.规范字 FROM tghb_variants AS v WHERE v\.异体字 = @ucs\)/)
+    assert.match(sql, /SELECT MJ文字図形名 FROM mjih_phonetic WHERE 音価 = @ucs/)
+    assert.match(sql, /subject >= @ucs AND subject < char\(unicode\(@ucs\) \+ 1\)/)
+    assert.match(sql, /object >= @ucs AND object < char\(unicode\(@ucs\) \+ 1\)/)
+    assert.doesNotMatch(sql, /glob\s+\(?@ucs\s*\|\|\s*'\*'/i)
+  })
 })

--- a/packages/mojidata-cli/bin/query-expressions.ts
+++ b/packages/mojidata-cli/bin/query-expressions.ts
@@ -18,7 +18,7 @@ export const queryExpressions = [
   ],
   [
     'ids_similar',
-    `(SELECT json_group_array(json_object('UCS', ids.UCS, 'IDS', ids.IDS, 'source', ids.source)) FROM ids WHERE ids.IDS glob ('[〾↔↷]' || @ucs))`,
+    `(SELECT json_group_array(json_object('UCS', ids.UCS, 'IDS', ids.IDS, 'source', ids.source)) FROM ids WHERE ids.IDS IN ('〾' || @ucs, '↔' || @ucs, '↷' || @ucs))`,
   ],
   [
     'ids_comment',
@@ -30,7 +30,8 @@ export const queryExpressions = [
         'char', ivs.IVS,
         'IVS', printf('%04X_%04X', unicode(ivs.IVS), unicode(substr(ivs.IVS, 2))),
         'collection', ivs.collection,
-        'code', ivs.code)) FROM ivs WHERE ivs.IVS glob (@ucs || '*'))`,
+        'code', ivs.code)) FROM ivs
+      WHERE ivs.IVS >= @ucs AND ivs.IVS < char(unicode(@ucs) + 1))`,
   ],
   [
     'svs_cjkci',
@@ -41,7 +42,7 @@ export const queryExpressions = [
             'CJKCI_char', CJKCI,
             'CJKCI', printf('U+%04X', unicode(CJKCI))))
         FROM svs_cjkci
-        WHERE (SVS glob @ucs || '*') OR (CJKCI glob @ucs || '*'))`,
+        WHERE (SVS >= @ucs AND SVS < char(unicode(@ucs) + 1)) OR CJKCI = @ucs)`,
   ],
   [
     'unihan',
@@ -110,7 +111,8 @@ export const queryExpressions = [
             )) FROM tghb_variants AS v WHERE v.规范字 = tghb.规范字)
         ))
         FROM tghb
-        WHERE @ucs = tghb.规范字 OR @ucs IN (SELECT v.异体字 FROM tghb_variants AS v WHERE v.规范字 = tghb.规范字)
+        WHERE tghb.规范字 = @ucs
+          OR tghb.规范字 IN (SELECT v.规范字 FROM tghb_variants AS v WHERE v.异体字 = @ucs)
     )`,
   ],
   [
@@ -186,16 +188,26 @@ export const queryExpressions = [
       '国語研URL', 国語研URL,
       '備考', 備考
     ))
-    FROM mjih WHERE @ucs = mjih.文字 OR @ucs = mjih.字母 OR @ucs IN (SELECT 音価 FROM mjih_phonetic AS p WHERE p.MJ文字図形名 = mjih.MJ文字図形名))`,
+    FROM mjih
+    WHERE MJ文字図形名 IN (
+      SELECT MJ文字図形名 FROM mjih WHERE 文字 = @ucs
+      UNION
+      SELECT MJ文字図形名 FROM mjih WHERE 字母 = @ucs
+      UNION
+      SELECT MJ文字図形名 FROM mjih_phonetic WHERE 音価 = @ucs
+    ))`,
   ],
   [
     'kdpv',
     `(
         SELECT json_group_object(rel, json(cs)) FROM (
             SELECT rel, json_group_array(c) AS cs FROM (
-                SELECT DISTINCT rel, object AS c FROM kdpv WHERE subject glob @ucs || '*'
+                SELECT DISTINCT rel, object AS c FROM kdpv
+                WHERE subject >= @ucs AND subject < char(unicode(@ucs) + 1)
                 UNION
-                SELECT DISTINCT ifnull(rev, '~' || kdpv.rel) AS rel, subject AS c FROM kdpv LEFT JOIN kdpv_rels ON kdpv_rels.rel = kdpv.rel WHERE object glob @ucs || '*'
+                SELECT DISTINCT ifnull(rev, '~' || kdpv.rel) AS rel, subject AS c
+                FROM kdpv LEFT JOIN kdpv_rels ON kdpv_rels.rel = kdpv.rel
+                WHERE object >= @ucs AND object < char(unicode(@ucs) + 1)
             )
             GROUP BY rel
         )

--- a/packages/mojidata-cli/bin/query-expressions.ts
+++ b/packages/mojidata-cli/bin/query-expressions.ts
@@ -18,7 +18,7 @@ export const queryExpressions = [
   ],
   [
     'ids_similar',
-    `(SELECT json_group_array(json_object('UCS', ids.UCS, 'IDS', ids.IDS, 'source', ids.source)) FROM ids WHERE ids.IDS IN ('〾' || @ucs, '↔' || @ucs, '↷' || @ucs))`,
+    `(SELECT json_group_array(json_object('UCS', ids.UCS, 'IDS', ids.IDS, 'source', ids.source)) FROM ids WHERE ids.IDS IN ('〾' || @ucs, '⿾' || @ucs, '⿿' || @ucs, '↔' || @ucs, '↷' || @ucs))`,
   ],
   [
     'ids_comment',

--- a/packages/mojidata/scripts/create-db.ts
+++ b/packages/mojidata/scripts/create-db.ts
@@ -425,6 +425,7 @@ async function createMjih(db: import("better-sqlite3").Database) {
 
     db.exec(`CREATE INDEX "mjih_文字" ON "mjih" ("文字")`)
     db.exec(`CREATE INDEX "mjih_字母" ON "mjih" ("字母")`)
+    db.exec(`CREATE INDEX "mjih_phonetic_MJ文字図形名" ON "mjih_phonetic" ("MJ文字図形名")`)
     db.exec(`CREATE INDEX "mjih_phonetic_文字" ON "mjih_phonetic" ("文字")`)
     db.exec(`CREATE INDEX "mjih_phonetic_音価" ON "mjih_phonetic" ("音価")`)
 }
@@ -1114,6 +1115,7 @@ async function createIDS(
     })
 
     db.exec(`CREATE INDEX "${prefix}_UCS" ON "${prefix}" ("UCS")`)
+    db.exec(`CREATE INDEX "${prefix}_IDS" ON "${prefix}" ("IDS")`)
     db.exec(`CREATE INDEX "${prefix}_comment_UCS" ON "${prefix}_comment" ("UCS")`)
 }
 

--- a/packages/mojidata/test.ts
+++ b/packages/mojidata/test.ts
@@ -10,6 +10,18 @@ test('lookup SVS', t => {
     t.deepEqual(svs, ['\u795E\uFE00'])
 })
 
+test('includes indexes for D1 full-field lookup predicates', t => {
+    const db = new Database(path.join(__dirname, 'dist', 'moji.db'))
+    const indexes = new Set(db.prepare(`
+        SELECT name FROM sqlite_schema
+        WHERE type = 'index'
+          AND name IN ('ids_IDS', 'mjih_phonetic_MJ文字図形名')
+    `).pluck().all())
+
+    t.true(indexes.has('ids_IDS'))
+    t.true(indexes.has('mjih_phonetic_MJ文字図形名'))
+})
+
 test('unihan_value_ref matches legacy unihan_fts scan semantics', t => {
     const db = new Database(path.join(__dirname, 'dist', 'moji.db'))
     const legacy = db.prepare(`


### PR DESCRIPTION
## Summary

- Optimize full-field D1 lookups so the generated SQL can use indexes, and add the required D1 schema indexes.
- Fix `ids_similar` to match the current IDS operators (`⿾`, `⿿`) while preserving legacy operator compatibility.
- Promote the D1 Worker bindings to the `20260504-d1-indexes` blue/green databases and clean up obsolete Cloudflare D1 databases.
- Add shared backend API conformance coverage plus non-D1 regression tests for `ids_similar`.
- Split database cache warmup into separate jobs for validation and release workflows so failed later steps do not force DB artifacts to be rebuilt every run.

## Related Issues

- Related: #41
- Related: #42
- Related: #43
- Related: #44

## Release Prep

- Pending changeset bumps `@mandel59/mojidata`, `@mandel59/mojidata-api-core`, and `@mandel59/mojidata-cli` at patch level.
- Version and changelog generation are intentionally left to the `Release` workflow after this feature PR is merged to `main`.

## Validation

- `corepack yarn changeset status --since=main`
- `corepack yarn ci:test`
- `corepack yarn ci:pack`
- `corepack yarn workspace @mandel59/mojidata-api test`
- `corepack yarn workspace @mandel59/mojidata-api-sqljs test`
- `corepack yarn workspace @mandel59/mojidata-api-better-sqlite3 test`
- `corepack yarn workspace @mandel59/mojidata-api-node-sqlite test`
- `corepack yarn workspace @mandel59/mojidata-api-sqlite-wasm test`
- `corepack yarn workspace @mandel59/mojidata-api-d1 test`
- `corepack yarn workspace @mandel59/mojidata-cli prepare`
- `corepack yarn mojidata-api:d1:check`
- `corepack yarn mojidata-api:d1:smoke -- --base-url https://mojidata-api-d1.mandel59.workers.dev`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/validate.yml'); puts 'validate.yml OK'"`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'release.yml OK'"`
- `corepack yarn build:idsdb-stack`
- `corepack yarn workspace @mandel59/idsdb-fts5 run prepare`